### PR TITLE
Fix bug pw building martial avenue

### DIFF
--- a/common/buildings/pw_amenities_buildings.txt
+++ b/common/buildings/pw_amenities_buildings.txt
@@ -222,7 +222,7 @@ pw_building_transplanetary_logistics_network = {
 	inline_script = {
 		script = jobs/pw/politician_add
 		OWNER_CONDITION = "is_egalitarian = yes"
-		SHOW_JOB_STEWARD_EFFECT_DESC = yes
+		# SHOW_JOB_STEWARD_EFFECT_DESC = yes
 		AMOUNT = 1
 	}
 
@@ -240,13 +240,13 @@ pw_building_transplanetary_logistics_network = {
 		AMOUNT = 1
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_egalitarian = yes }
-		}
-		text = job_clerk_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_egalitarian = yes }
+	# 	}
+	# 	text = job_clerk_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.1700 }
@@ -540,7 +540,7 @@ pw_building_transhabitat_logistics_network = {
 	inline_script = {
 		script = jobs/pw/politician_add
 		OWNER_CONDITION = "is_egalitarian = yes"
-		SHOW_JOB_STEWARD_EFFECT_DESC = yes
+		# SHOW_JOB_STEWARD_EFFECT_DESC = yes
 		AMOUNT = 1
 	}
 
@@ -557,13 +557,13 @@ pw_building_transhabitat_logistics_network = {
 		AMOUNT = 1
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_egalitarian = yes }
-		}
-		text = job_clerk_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_egalitarian = yes }
+	# 	}
+	# 	text = job_clerk_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.1700 }
@@ -783,42 +783,44 @@ pw_building_festival_plaza = {
 	inline_script = {
 		script = jobs/pw/politician_add
 		OWNER_CONDITION = "is_pacifist = yes"
-		SHOW_JOB_STEWARD_EFFECT_DESC = no
+		# SHOW_JOB_STEWARD_EFFECT_DESC = no
 		AMOUNT = 1
 	}
-	inline_script = {
-		script = jobs/pw/culture_worker_add
-		OWNER_CONDITION = "is_pacifist = yes"
-		AMOUNT = 3
-	}
+	# inline_script = {
+	# 	script = jobs/pw/culture_worker_add
+	# 	OWNER_CONDITION = "is_pacifist = yes"
+	# 	AMOUNT = 3
+	# }
 
+	# culture worker (bureaucrat)
 	#Entertainer
 	triggered_planet_modifier = {
 		potential = {
 			exists = owner
 			owner = {
 				is_pacifist = yes
-				NOT = { has_valid_civic = civic_warrior_culture }
+				# NOT = { has_valid_civic = civic_warrior_culture }
 			}
 		}
 		modifier = {
+			job_bureaucrat_add = 300
 			job_entertainer_add = 300
 		}
 	}
 
 	#Duelist
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_pacifist = yes
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		modifier = {
-			job_duelist_add = 300
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_pacifist = yes
+	# 			has_valid_civic = civic_warrior_culture
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_duelist_add = 300
+	# 	}
+	# }
 
 	#Stability from ambition
 	triggered_planet_modifier = {
@@ -868,23 +870,23 @@ pw_building_festival_plaza = {
 	# 	text = job_executive_effect_desc
 	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_pacifist = yes }
-			NOT = { owner = { has_valid_civic = civic_warrior_culture }}
-		}
-		text = job_entertainer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_pacifist = yes }
+	# 		NOT = { owner = { has_valid_civic = civic_warrior_culture }}
+	# 	}
+	# 	text = job_entertainer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_pacifist = yes }
-			owner = { has_valid_civic = civic_warrior_culture }
-		}
-		text = job_duelist_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_pacifist = yes }
+	# 		owner = { has_valid_civic = civic_warrior_culture }
+	# 	}
+	# 	text = job_duelist_effect_desc
+	# }
 
 	# triggered_desc = {
 	# 	trigger = {
@@ -1095,13 +1097,13 @@ pw_building_nostalgia_paradise = {
 	}
 
 	#Merchant
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_merchant_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_merchant_effect_desc
+	# }
 
 	# #Administrator(1)
 	# triggered_planet_modifier = {
@@ -1148,44 +1150,50 @@ pw_building_nostalgia_paradise = {
 	# 		job_manager_add = 200
 	# 	}
 	# }
+	# inline_script = {
+	# 	script = jobs/pw/politician_add
+	# 	OWNER_CONDITION = ""
+	# 	SHOW_JOB_STEWARD_EFFECT_DESC = no
+	# 	AMOUNT = 1
+	# }
 	inline_script = {
-		script = jobs/pw/politician_add
-		OWNER_CONDITION = ""
-		SHOW_JOB_STEWARD_EFFECT_DESC = no
-		AMOUNT = 1
+		script = jobs/politician_add
+		AMOUNT = 100
 	}
-	inline_script = {
-		script = jobs/pw/culture_worker_add
-		OWNER_CONDITION = ""
-		AMOUNT = 2
-	}
+	# inline_script = {
+	# 	script = jobs/pw/culture_worker_add
+	# 	OWNER_CONDITION = ""
+	# 	AMOUNT = 2
+	# }
 
+	# culture worker (bureaucrat)
 	#Entertainers (2)
 	triggered_planet_modifier = {
 		potential = {
 			exists = owner
 			owner = { is_regular_empire = yes }
-			owner = {
-				NOT = { has_valid_civic = civic_warrior_culture }
-			}
+			# owner = {
+			# 	NOT = { has_valid_civic = civic_warrior_culture }
+			# }
 		}
 		modifier = {
+			job_bureaucrat_add = 200
 			job_entertainer_add = 200
 		}
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-			owner = {
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		modifier = {
-			job_duelist_add = 200
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 		owner = {
+	# 			has_valid_civic = civic_warrior_culture
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_duelist_add = 200
+	# 	}
+	# }
 
 	#Spa Attendants (1) (only mutagenic spas)
 	triggered_planet_modifier = {
@@ -1197,7 +1205,7 @@ pw_building_nostalgia_paradise = {
 			}
 		}
 		modifier = {
-			job_bath_attendant_add = 100
+			job_healthcare_add = 100
 		}
 	}
 
@@ -1211,7 +1219,7 @@ pw_building_nostalgia_paradise = {
 		modifier = {
 			job_bio_trophy_add = 1000
 			job_artisan_drone_add = 100
-			job_maintenance_drone_add = 500
+			# job_maintenance_drone_add = 500
 		}
 	}
 
@@ -1223,7 +1231,7 @@ pw_building_nostalgia_paradise = {
 			owner = { has_toxic_baths = yes }
 		}
 		modifier = {
-			job_bath_attendant_machine_add = 100
+			job_replicator_add = 100
 		}
 	}
 
@@ -1304,77 +1312,77 @@ pw_building_nostalgia_paradise = {
 	# }
 
 	#Entertainer
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-			owner = {
-				NOT = { has_valid_civic = civic_warrior_culture }
-			}
-		}
-		text = job_entertainer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 		owner = {
+	# 			NOT = { has_valid_civic = civic_warrior_culture }
+	# 		}
+	# 	}
+	# 	text = job_entertainer_effect_desc
+	# }
 
-	#Spa Attendants (1) (only mutagenic spas)
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-			owner = {
-				has_toxic_baths = yes
-			}
-		}
-		text = job_toxic_baths_effect_desc
-	}
+	# #Spa Attendants (1) (only mutagenic spas)
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 		owner = {
+	# 			has_toxic_baths = yes
+	# 		}
+	# 	}
+	# 	text = job_toxic_baths_effect_desc
+	# }
 
-	#Duelist
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-			owner = {
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		text = job_duelist_effect_desc
-	}
+	# #Duelist
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 		owner = {
+	# 			has_valid_civic = civic_warrior_culture
+	# 		}
+	# 	}
+	# 	text = job_duelist_effect_desc
+	# }
 
 	#Trophy
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { has_valid_civic = civic_machine_servitor }
-		}
-		text = job_bio_trophy_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { has_valid_civic = civic_machine_servitor }
+	# 	}
+	# 	text = job_bio_trophy_effect_desc
+	# }
 
-	#Artisan
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { has_valid_civic = civic_machine_servitor }
-		}
-		text = job_artisan_drone_effect_desc
-	}
+	# #Artisan
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { has_valid_civic = civic_machine_servitor }
+	# 	}
+	# 	text = job_artisan_drone_effect_desc
+	# }
 
-	#Lubricator terminal (1) for toxic baths
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { has_valid_civic = civic_machine_servitor }
-			owner = { has_toxic_baths = yes }
-		}
-		text = job_toxic_baths_effect_machine_desc
-	}
+	# #Lubricator terminal (1) for toxic baths
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { has_valid_civic = civic_machine_servitor }
+	# 		owner = { has_toxic_baths = yes }
+	# 	}
+	# 	text = job_toxic_baths_effect_machine_desc
+	# }
 
-	#Maintenance
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { has_valid_civic = civic_machine_servitor }
-		}
-		text = job_maintenance_drone_effect_desc
-	}
+	# #Maintenance
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { has_valid_civic = civic_machine_servitor }
+	# 	}
+	# 	text = job_maintenance_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.2300 }
@@ -1583,7 +1591,7 @@ pw_building_blossoming_preserve = {
 	inline_script = {
 		script = jobs/pw/politician_add
 		OWNER_CONDITION = "is_gestalt = no"
-		SHOW_JOB_STEWARD_EFFECT_DESC = yes
+		# SHOW_JOB_STEWARD_EFFECT_DESC = yes
 		AMOUNT = 1
 	}
 
@@ -1680,30 +1688,30 @@ pw_building_blossoming_preserve = {
 	# }
 
 	#Preservers
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			OR = {
-				merg_is_gaia = yes
-				merg_is_hive_world = yes
-			}
-		}
-		text = job_pw_preserver_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		OR = {
+	# 			merg_is_gaia = yes
+	# 			merg_is_hive_world = yes
+	# 		}
+	# 	}
+	# 	text = job_pw_preserver_effect_desc
+	# }
 
-	#Preserver Drone
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-			OR = {
-				merg_is_gaia = yes
-				merg_is_hive_world = yes
-			}
-		}
-		text = job_pw_preserver_drone_effect_desc
-	}
+	# #Preserver Drone
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 		OR = {
+	# 			merg_is_gaia = yes
+	# 			merg_is_hive_world = yes
+	# 		}
+	# 	}
+	# 	text = job_pw_preserver_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.2500 }

--- a/common/buildings/pw_army_buildings.txt
+++ b/common/buildings/pw_army_buildings.txt
@@ -229,56 +229,56 @@ pw_building_guardian_angel = {
 		text = pw_guardian_angel_tooltip
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_soldier_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_soldier_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { has_valid_civic = civic_reanimated_armies }
-		}
-		text = job_necromancer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { has_valid_civic = civic_reanimated_armies }
+	# 	}
+	# 	text = job_necromancer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { NOT = { has_active_tradition = tr_psionics_psi_corps }}
-		}
-		text = job_enforcer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { NOT = { has_active_tradition = tr_psionics_psi_corps }}
+	# 	}
+	# 	text = job_enforcer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { has_active_tradition = tr_psionics_psi_corps }
-		}
-		text = job_telepath_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { has_active_tradition = tr_psionics_psi_corps }
+	# 	}
+	# 	text = job_telepath_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_warrior_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_warrior_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_patrol_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_patrol_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.1200 }
@@ -580,56 +580,56 @@ pw_building_stellar_sentinel = {
 		text = pw_guardian_angel_tooltip
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_soldier_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_soldier_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { has_valid_civic = civic_reanimated_armies }
-		}
-		text = job_necromancer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { has_valid_civic = civic_reanimated_armies }
+	# 	}
+	# 	text = job_necromancer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { NOT = { has_active_tradition = tr_psionics_psi_corps }}
-		}
-		text = job_enforcer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { NOT = { has_active_tradition = tr_psionics_psi_corps }}
+	# 	}
+	# 	text = job_enforcer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { has_active_tradition = tr_psionics_psi_corps }
-		}
-		text = job_telepath_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { has_active_tradition = tr_psionics_psi_corps }
+	# 	}
+	# 	text = job_telepath_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_warrior_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_warrior_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_patrol_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_patrol_drone_effect_desc
+	# }
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
@@ -861,42 +861,44 @@ pw_building_martial_avenue = {
 	inline_script = {
 		script = jobs/pw/politician_add
 		OWNER_CONDITION = "is_militarist = yes"
-		SHOW_JOB_STEWARD_EFFECT_DESC = no
+		# SHOW_JOB_STEWARD_EFFECT_DESC = no
 		AMOUNT = 1
 	}
-	inline_script = {
-		script = jobs/pw/culture_worker_add
-		OWNER_CONDITION = "is_militarist = yes"
-		AMOUNT = 2
-	}
+	# inline_script = {
+	# 	script = jobs/pw/culture_worker_add
+	# 	OWNER_CONDITION = "is_militarist = yes"
+	# 	AMOUNT = 2
+	# }
 
+	# culture worker (bureaucrat)
 	#Entertainer
 	triggered_planet_modifier = {
 		potential = {
 			exists = owner
 			owner = {
 				is_militarist = yes
-				NOT = { has_valid_civic = civic_warrior_culture }
+				# NOT = { has_valid_civic = civic_warrior_culture }
 			}
 		}
 		modifier = {
+			job_bureaucrat_add = 200
 			job_entertainer_add = 200
 		}
 	}
 
 	#Duelist
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_militarist = yes
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		modifier = {
-			job_duelist_add = 200
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_militarist = yes
+	# 			has_valid_civic = civic_warrior_culture
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_duelist_add = 200
+	# 	}
+	# }
 
 	#Soldier
 	triggered_planet_modifier = {
@@ -975,23 +977,23 @@ pw_building_martial_avenue = {
 	# 	text = job_executive_effect_desc
 	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_militarist = yes }
-			NOT = { owner = { has_valid_civic = civic_warrior_culture }}
-		}
-		text = job_entertainer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_militarist = yes }
+	# 		NOT = { owner = { has_valid_civic = civic_warrior_culture }}
+	# 	}
+	# 	text = job_entertainer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_militarist = yes }
-			owner = { has_valid_civic = civic_warrior_culture }
-		}
-		text = job_duelist_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_militarist = yes }
+	# 		owner = { has_valid_civic = civic_warrior_culture }
+	# 	}
+	# 	text = job_duelist_effect_desc
+	# }
 
 	# triggered_desc = {
 	# 	trigger = {
@@ -1011,22 +1013,22 @@ pw_building_martial_avenue = {
 	# 	text = job_manager_effect_desc
 	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_militarist = yes }
-		}
-		text = job_soldier_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_militarist = yes }
+	# 	}
+	# 	text = job_soldier_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_militarist = yes }
-			owner = { has_valid_civic = civic_reanimated_armies }
-		}
-		text = job_necromancer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_militarist = yes }
+	# 		owner = { has_valid_civic = civic_reanimated_armies }
+	# 	}
+	# 	text = job_necromancer_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.2000 }

--- a/common/buildings/pw_army_buildings.txt
+++ b/common/buildings/pw_army_buildings.txt
@@ -906,7 +906,7 @@ pw_building_martial_avenue = {
 			exists = owner
 			owner = {
 				is_militarist = yes
-				NOT = { has_valid_civic = civic_reanimated_armies }
+				# NOT = { has_valid_civic = civic_reanimated_armies }
 			}
 		}
 		modifier = {
@@ -915,19 +915,19 @@ pw_building_martial_avenue = {
 	}
 
 	#Necromancer
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_militarist = yes
-				has_valid_civic = civic_reanimated_armies
-			}
-		}
-		modifier = {
-			job_soldier_add = 100
-			job_necromancer_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_militarist = yes
+	# 			has_valid_civic = civic_reanimated_armies
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_soldier_add = 100
+	# 		job_necromancer_add = 100
+	# 	}
+	# }
 
 	#Stability from ambition
 	triggered_planet_modifier = {

--- a/common/buildings/pw_branch_office_buildings.txt
+++ b/common/buildings/pw_branch_office_buildings.txt
@@ -74,33 +74,34 @@ pw_building_bloodsports_arena = {
 		branch_office_value_mult = 0.15
 		pop_ethic_militarist_attraction_mult = 0.20
 		job_clerk_add = 100
+		job_entertainer_add = 100
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_gestalt = no
-				NOT = { has_valid_civic = civic_warrior_culture }
-			}
-		}
-		modifier = {
-			job_entertainer_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_gestalt = no
+	# 			NOT = { has_valid_civic = civic_warrior_culture }
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_entertainer_add = 100
+	# 	}
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_gestalt = no
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		modifier = {
-			job_duelist_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_gestalt = no
+	# 			has_valid_civic = civic_warrior_culture
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_duelist_add = 100
+	# 	}
+	# }
 
 	triggered_planet_modifier = {
 		potential = {
@@ -219,6 +220,7 @@ pw_building_meditation_garden = {
 		branch_office_value_mult = 0.15
 		pop_ethic_pacifist_attraction_mult = 0.20
 		job_clerk_add = 100
+		job_bureaucrat_add = 100
 	}
 
 	# #Bureaucrat
@@ -253,7 +255,7 @@ pw_building_meditation_garden = {
 			}
 		}
 		modifier = {
-			job_culture_worker_add = 100
+			job_bureaucrat_add = 100
 		}
 	}
 
@@ -271,11 +273,11 @@ pw_building_meditation_garden = {
 		text = pw_branch_office_unique_lb
 	}
 
-	inline_script = {
-		script = jobs/pw/bureaucrat_add
-		OWNER_CONDITION = ""
-		AMOUNT = 1
-	}
+	# inline_script = {
+	# 	script = jobs/pw/bureaucrat_add
+	# 	OWNER_CONDITION = ""
+	# 	AMOUNT = 1
+	# }
 
 	on_built = {
 		planet_event = { id = pw_branch_office.120 }
@@ -497,7 +499,7 @@ pw_building_salvation_shrine = {
 			}
 		}
 		modifier = {
-			job_preacher_add = 100
+			job_bureaucrat_add = 100
 		}
 	}
 
@@ -509,7 +511,7 @@ pw_building_salvation_shrine = {
 				# This building is a corporate branch (can be built on non-corporate planet).
 				# So planet owner is not megacorp always.
 	# 			is_megacorp = no
-				NOT = { has_origin = origin_cybernetic_creed }
+				# NOT = { has_origin = origin_cybernetic_creed }
 			}
 		}
 		modifier = {
@@ -517,41 +519,41 @@ pw_building_salvation_shrine = {
 		}
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				has_ethic = ethic_fanatic_spiritualist
-	# 			is_megacorp = no
-				NOT = { has_origin = origin_cybernetic_creed }
-			}
-		}
-		text = job_priest_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			has_ethic = ethic_fanatic_spiritualist
+	# # 			is_megacorp = no
+	# 			NOT = { has_origin = origin_cybernetic_creed }
+	# 		}
+	# 	}
+	# 	text = job_priest_effect_desc
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				has_ethic = ethic_fanatic_spiritualist
-				has_origin = origin_cybernetic_creed
-			}
-		}
-		modifier = {
-			job_haruspex_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			has_ethic = ethic_fanatic_spiritualist
+	# 			has_origin = origin_cybernetic_creed
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_haruspex_add = 100
+	# 	}
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				has_ethic = ethic_fanatic_spiritualist
-				has_origin = origin_cybernetic_creed
-			}
-		}
-		text = job_haruspex_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			has_ethic = ethic_fanatic_spiritualist
+	# 			has_origin = origin_cybernetic_creed
+	# 		}
+	# 	}
+	# 	text = job_haruspex_effect_desc
+	# }
 
 	# triggered_planet_modifier = {
 	# 	potential = {
@@ -566,26 +568,26 @@ pw_building_salvation_shrine = {
 	# 	}
 	# }
 
-	triggered_desc = {
-		trigger = {
-	# 		or = {
-	# 			and = {
-					exists = branch_office_owner
-					branch_office_owner = {
-						has_valid_civic = civic_gospel_of_the_masses
-					}
-	# 			}
-	# 			and = {
-	# 				exists = owner
-	# 				owner = {
-	# 					has_ethic = ethic_fanatic_spiritualist
-	# 					is_megacorp = yes
+	# triggered_desc = {
+	# 	trigger = {
+	# # 		or = {
+	# # 			and = {
+	# 				exists = branch_office_owner
+	# 				branch_office_owner = {
+	# 					has_valid_civic = civic_gospel_of_the_masses
 	# 				}
-	# 			}
-	# 		}
-		}
-		text = job_preacher_effect_desc
-	}
+	# # 			}
+	# # 			and = {
+	# # 				exists = owner
+	# # 				owner = {
+	# # 					has_ethic = ethic_fanatic_spiritualist
+	# # 					is_megacorp = yes
+	# # 				}
+	# # 			}
+	# # 		}
+	# 	}
+	# 	text = job_preacher_effect_desc
+	# }
 
 	triggered_planet_modifier = {
 		potential = {
@@ -703,7 +705,7 @@ pw_building_exotic_beauty_center = {
 			}
 		}
 		modifier = {
-			job_culture_worker_add = 100
+			job_bureaucrat_add = 100
 		}
 	}
 
@@ -823,7 +825,7 @@ pw_building_national_pride_gallery = {
 			}
 		}
 		modifier = {
-			job_culture_worker_add = 100
+			job_bureaucrat_add = 100
 		}
 	}
 

--- a/common/buildings/pw_general_buildings.txt
+++ b/common/buildings/pw_general_buildings.txt
@@ -47,7 +47,7 @@ pw_building_polyhedron = {
 		}
 		modifier = {
 			inline_script = { script = jobs/pw/researcher_add AMOUNT = 100 }
-			job_culture_worker_add = 200
+			job_bureaucrat_add = 200
 		}
 	}
 
@@ -75,51 +75,51 @@ pw_building_polyhedron = {
 		}
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_bureaucrat_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_bureaucrat_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_brain_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_brain_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_synapse_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_synapse_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_calculator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_calculator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_evaluator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_evaluator_effect_desc
+	# }
 }

--- a/common/buildings/pw_gestalt_buildings.txt
+++ b/common/buildings/pw_gestalt_buildings.txt
@@ -275,7 +275,7 @@ pw_building_conduit_of_unity_1 = {
 		}
 		modifier = {
 			planet_housing_add = 800
-			job_maintenance_drone_add = 500
+			# job_maintenance_drone_add = 500
 		}
 	}
 
@@ -286,7 +286,7 @@ pw_building_conduit_of_unity_1 = {
 		}
 		modifier = {
 			planet_housing_add = 600
-			job_maintenance_drone_add = 300
+			# job_maintenance_drone_add = 300
 		}
 	}
 
@@ -300,7 +300,7 @@ pw_building_conduit_of_unity_1 = {
 		}
 		modifier = {
 			planet_housing_add = 1600
-			job_maintenance_drone_add = 1000
+			# job_maintenance_drone_add = 1000
 		}
 	}
 
@@ -311,7 +311,7 @@ pw_building_conduit_of_unity_1 = {
 		}
 		modifier = {
 			planet_housing_add = 2400
-			job_maintenance_drone_add = 1500
+			# job_maintenance_drone_add = 1500
 		}
 	}
 
@@ -344,7 +344,7 @@ pw_building_conduit_of_unity_1 = {
 		potential = {
 			owner = {
 				is_machine_empire = yes
-				has_toxic_baths = no
+				# has_toxic_baths = no
 			}
 		}
 		modifier = {
@@ -353,17 +353,17 @@ pw_building_conduit_of_unity_1 = {
 	}
 
 	#Lubricants
-	triggered_planet_modifier = {
-		potential = {
-			owner = {
-				is_machine_empire = yes
-				has_toxic_baths = yes
-			}
-		}
-		modifier = {
-			job_bath_attendant_machine_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		owner = {
+	# 			is_machine_empire = yes
+	# 			has_toxic_baths = yes
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_bath_attendant_machine_add = 100
+	# 	}
+	# }
 
 	#Replicator -> AP
 	triggered_planet_modifier = {
@@ -396,7 +396,7 @@ pw_building_conduit_of_unity_1 = {
 		potential = {
 			owner = {
 				is_hive_empire = yes
-				has_toxic_baths = no
+				# has_toxic_baths = no
 			}
 		}
 		modifier = {
@@ -405,17 +405,17 @@ pw_building_conduit_of_unity_1 = {
 	}
 
 	#Permutation
-	triggered_planet_modifier = {
-		potential = {
-			owner = {
-				is_hive_empire = yes
-				has_toxic_baths = yes
-			}
-		}
-		modifier = {
-			job_bath_attendant_hive_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		owner = {
+	# 			is_hive_empire = yes
+	# 			has_toxic_baths = yes
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_bath_attendant_hive_add = 100
+	# 	}
+	# }
 
 	#Spawning Drone -> from tradition
 	triggered_planet_modifier = {
@@ -479,75 +479,75 @@ pw_building_conduit_of_unity_1 = {
 		text = pw_planet_wonder_lb
 	}
 	#Patrol
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_patrol_drone_effect_desc
-	}
-	#Coordinator
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_coordinator_effect_desc
-	}
-	#Replicator
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_replicator_effect_desc
-	}
-	#Lubricant
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				is_machine_empire = yes
-				has_toxic_baths = yes
-			}
-		}
-		text = job_toxic_baths_effect_machine_desc
-	}
-	#Synapsis
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_synapse_drone_effect_desc
-	}
-	#Spawning
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_spawning_drone_effect_desc
-	}
-	#Permutation
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				is_hive_empire = yes
-				has_toxic_baths = yes
-			}
-		}
-		text = job_toxic_baths_effect_hive_desc
-	}
-	#Maintenance
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_maintenance_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_patrol_drone_effect_desc
+	# }
+	# #Coordinator
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_coordinator_effect_desc
+	# }
+	# #Replicator
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_replicator_effect_desc
+	# }
+	# #Lubricant
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_machine_empire = yes
+	# 			has_toxic_baths = yes
+	# 		}
+	# 	}
+	# 	text = job_toxic_baths_effect_machine_desc
+	# }
+	# #Synapsis
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_synapse_drone_effect_desc
+	# }
+	# #Spawning
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_spawning_drone_effect_desc
+	# }
+	# #Permutation
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_hive_empire = yes
+	# 			has_toxic_baths = yes
+	# 		}
+	# 	}
+	# 	text = job_toxic_baths_effect_hive_desc
+	# }
+	# #Maintenance
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_maintenance_drone_effect_desc
+	# }
 
 	ai_weight = {
 		weight = 70
@@ -781,13 +781,13 @@ pw_building_enigma_engine = {
 		text = pw_enigma_engine_tooltip
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_pw_enigma_decipher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_pw_enigma_decipher_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.1000 }
@@ -960,7 +960,7 @@ pw_building_solipsist_debate_hall = {
 		}
 		modifier = {
 			#Simple
-			job_maintenance_drone_per_pop = @pw_job_per_25_pop
+			# job_maintenance_drone_per_pop = @pw_job_per_25_pop
 			job_warrior_drone_per_pop = @pw_job_per_50_pop
 
 			#Complex
@@ -981,7 +981,7 @@ pw_building_solipsist_debate_hall = {
 		}
 		modifier = {
 			#Simple
-			job_maintenance_drone_per_pop = @pw_job_per_25_pop
+			# job_maintenance_drone_per_pop = @pw_job_per_25_pop
 			job_warrior_drone_per_pop = @pw_job_per_30_pop
 
 			#Complex
@@ -1000,7 +1000,7 @@ pw_building_solipsist_debate_hall = {
 			}
 		}
 		modifier = {
-			job_bath_attendant_hive_add = 100
+			job_spawning_drone_add = 100
 		}
 	}
 
@@ -1245,76 +1245,76 @@ pw_building_solipsist_debate_hall = {
 		text = pw_solipsist_debate_hall_tooltip
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_maintenance_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_maintenance_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_warrior_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_warrior_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_spawning_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_spawning_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_patrol_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_patrol_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-			NOT = { owner = { has_valid_civic = civic_hive_devouring_swarm }}
-		}
-		text = job_synapse_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 		NOT = { owner = { has_valid_civic = civic_hive_devouring_swarm }}
+	# 	}
+	# 	text = job_synapse_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-			NOT = { owner = { has_valid_civic = civic_hive_devouring_swarm }}
-		}
-		text = job_brain_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 		NOT = { owner = { has_valid_civic = civic_hive_devouring_swarm }}
+	# 	}
+	# 	text = job_brain_drone_effect_desc
+	# }
 
-	#Permutation
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				is_hive_empire = yes
-				has_toxic_baths = yes
-			}
-		}
-		text = job_toxic_baths_effect_hive_desc
-	}
+	# #Permutation
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_hive_empire = yes
+	# 			has_toxic_baths = yes
+	# 		}
+	# 	}
+	# 	text = job_toxic_baths_effect_hive_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { has_valid_civic = civic_hive_memorialist }
-			owner = { has_edict = pw_wonders_beyond_ambition }
-		}
-		text = job_chronicle_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { has_valid_civic = civic_hive_memorialist }
+	# 		owner = { has_edict = pw_wonders_beyond_ambition }
+	# 	}
+	# 	text = job_chronicle_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.1100 }
@@ -1478,7 +1478,7 @@ pw_building_feasting_grounds = {
 		}
 		modifier = {
 			#Simple
-			job_maintenance_drone_add = 200
+			# job_maintenance_drone_add = 200
 			job_warrior_drone_add = 200
 
 			#Complex
@@ -1495,7 +1495,7 @@ pw_building_feasting_grounds = {
 		}
 		modifier = {
 			#Simple
-			job_maintenance_drone_add = 200
+			# job_maintenance_drone_add = 200
 			job_warrior_drone_add = 200
 
 			#Complex
@@ -1536,38 +1536,38 @@ pw_building_feasting_grounds = {
 		text = pw_building_feasting_grounds_tooltip
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_maintenance_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_maintenance_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_warrior_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_warrior_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_patrol_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_patrol_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-			owner = { has_valid_civic = civic_hive_devouring_swarm }
-		}
-		text = job_pw_banquet_steward_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 		owner = { has_valid_civic = civic_hive_devouring_swarm }
+	# 	}
+	# 	text = job_pw_banquet_steward_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.2700 }

--- a/common/buildings/pw_government_buildings.txt
+++ b/common/buildings/pw_government_buildings.txt
@@ -292,23 +292,23 @@ pw_building_galactic_model = {
 	# 	text = pw_building_galactic_model_policy_tooltip
 	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-			owner = { is_megacorp = no }
-		}
-		text = job_politician_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 		owner = { is_megacorp = no }
+	# 	}
+	# 	text = job_politician_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-			owner = { is_megacorp = yes }
-		}
-		text = job_executive_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 		owner = { is_megacorp = yes }
+	# 	}
+	# 	text = job_executive_effect_desc
+	# }
 
 	# triggered_desc = {
 	# 	trigger = {
@@ -323,29 +323,29 @@ pw_building_galactic_model = {
 		AMOUNT = 8
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_synapse_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_synapse_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_coordinator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_coordinator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_evaluator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_evaluator_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.800 }
@@ -701,23 +701,23 @@ pw_building_aligned_galactic_model = {
 	# 	text = pw_building_galactic_model_policy_tooltip
 	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-			owner = { is_megacorp = no }
-		}
-		text = job_politician_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 		owner = { is_megacorp = no }
+	# 	}
+	# 	text = job_politician_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-			owner = { is_megacorp = yes }
-		}
-		text = job_executive_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 		owner = { is_megacorp = yes }
+	# 	}
+	# 	text = job_executive_effect_desc
+	# }
 
 	# triggered_desc = {
 	# 	trigger = {
@@ -732,37 +732,37 @@ pw_building_aligned_galactic_model = {
 		AMOUNT = 10
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_synapse_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_synapse_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_coordinator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_coordinator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_evaluator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_evaluator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_pw_logistics_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_pw_logistics_drone_effect_desc
+	# }
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
@@ -1073,7 +1073,7 @@ pw_building_panopticon = {
 			owner = { has_technology = pw_tech_panopticon_criminal_reintegration }
 		}
 		modifier = {
-			job_culture_worker_add = 200
+			job_bureaucrat_add = 200
 		}
 	}
 
@@ -1187,87 +1187,87 @@ pw_building_panopticon = {
 		text = pw_planet_wonder_lb
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { is_megacorp = no }
-		}
-		text = job_politician_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { is_megacorp = no }
+	# 	}
+	# 	text = job_politician_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { is_megacorp = yes }
-		}
-		text = job_executive_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { is_megacorp = yes }
+	# 	}
+	# 	text = job_executive_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			NOT = { owner = { has_active_tradition = tr_psionics_psi_corps }}
-		}
-		text = job_enforcer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		NOT = { owner = { has_active_tradition = tr_psionics_psi_corps }}
+	# 	}
+	# 	text = job_enforcer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { has_active_tradition = tr_psionics_psi_corps }
-		}
-		text = job_telepath_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { has_active_tradition = tr_psionics_psi_corps }
+	# 	}
+	# 	text = job_telepath_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-			owner = { has_edict = pw_edict_panspectron }
-		}
-		text = job_pw_big_brother_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 		owner = { has_edict = pw_edict_panspectron }
+	# 	}
+	# 	text = job_pw_big_brother_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_patrol_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_patrol_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_patrol_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_patrol_drone_effect_desc
+	# }
 
-	inline_script = {
-		script = jobs/pw/foundry_effect_desc
-		OWNER_CONDITION = "is_authoritarian = yes
-						   has_technology = pw_tech_panopticon_penal_industries"
-	}
+	# inline_script = {
+	# 	script = jobs/pw/foundry_effect_desc
+	# 	OWNER_CONDITION = "is_authoritarian = yes
+	# 					   has_technology = pw_tech_panopticon_penal_industries"
+	# }
 
-	inline_script = {
-		script = jobs/pw/factory_effect_desc
-		OWNER_CONDITION = "is_authoritarian = yes
-						   has_technology = pw_tech_panopticon_penal_industries"
-	}
+	# inline_script = {
+	# 	script = jobs/pw/factory_effect_desc
+	# 	OWNER_CONDITION = "is_authoritarian = yes
+	# 					   has_technology = pw_tech_panopticon_penal_industries"
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_egalitarian = yes }
-			owner = { has_technology = pw_tech_panopticon_criminal_reintegration }
-		}
-		text = job_bureaucrat_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_egalitarian = yes }
+	# 		owner = { has_technology = pw_tech_panopticon_criminal_reintegration }
+	# 	}
+	# 	text = job_bureaucrat_effect_desc
+	# }
 
 	# triggered_desc = {
 	# 	trigger = {
@@ -1291,29 +1291,28 @@ pw_building_panopticon = {
 
 	inline_script = {
 		script = jobs/pw/bureaucrat_add
-		OWNER_CONDITION = "is_pacifist = yes
-						   has_technology = pw_tech_panopticon_reformatory_bureaucratic_work"
+		OWNER_CONDITION = "is_pacifist = yes has_technology = pw_tech_panopticon_reformatory_bureaucratic_work"
 		AMOUNT = 2
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_militarist = yes }
-			owner = { has_technology = pw_tech_panopticon_enlist_prisoners }
-		}
-		text = job_soldier_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_militarist = yes }
+	# 		owner = { has_technology = pw_tech_panopticon_enlist_prisoners }
+	# 	}
+	# 	text = job_soldier_effect_desc
+	# }
 
-	inline_script = {
-		script = jobs/pw/bureaucrat_effect_desc
-		OWNER_CONDITION =  "is_spiritualist = yes
-							has_technology = pw_tech_panopticon_repentance_preaching
-		    				nand = {
-		    					is_pacifist = yes
-		    					has_technology = pw_tech_panopticon_reformatory_bureaucratic_work
-		    				}"
-	}
+	# inline_script = {
+	# 	script = jobs/pw/bureaucrat_effect_desc
+	# 	OWNER_CONDITION =  "is_spiritualist = yes
+	# 						has_technology = pw_tech_panopticon_repentance_preaching
+	# 	    				nand = {
+	# 	    					is_pacifist = yes
+	# 	    					has_technology = pw_tech_panopticon_reformatory_bureaucratic_work
+	# 	    				}"
+	# }
 	# triggered_desc = {
 	# 	trigger = {
 	# 		exists = owner
@@ -1348,15 +1347,15 @@ pw_building_panopticon = {
 	# 	text = job_preacher_effect_desc
 	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_pacifist = yes }
-			owner = { is_materialist = yes }
-			owner = { has_technology = pw_tech_panopticon_prisoner_subjects }
-		}
-		text = job_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_pacifist = yes }
+	# 		owner = { is_materialist = yes }
+	# 		owner = { has_technology = pw_tech_panopticon_prisoner_subjects }
+	# 	}
+	# 	text = job_researcher_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.900 }
@@ -1684,95 +1683,95 @@ pw_building_forbidden_city = {
 		text = pw_forbidden_city_tooltip
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				is_authoritarian = yes
-				is_megacorp = no
-				NOT = { has_valid_civic = civic_merchant_guilds }
-				NOT = { has_valid_civic = civic_aristocratic_elite }
-				NOT = { has_valid_civic = civic_technocracy }
-				NOT = { has_valid_civic = civic_exalted_priesthood }
-				NOT = { has_valid_civic = civic_merchant_guilds }
-			}
-		}
-		text = job_politician_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_authoritarian = yes
+	# 			is_megacorp = no
+	# 			NOT = { has_valid_civic = civic_merchant_guilds }
+	# 			NOT = { has_valid_civic = civic_aristocratic_elite }
+	# 			NOT = { has_valid_civic = civic_technocracy }
+	# 			NOT = { has_valid_civic = civic_exalted_priesthood }
+	# 			NOT = { has_valid_civic = civic_merchant_guilds }
+	# 		}
+	# 	}
+	# 	text = job_politician_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_authoritarian = yes }
-			owner = { is_megacorp = yes }
-		}
-		text = job_executive_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_authoritarian = yes }
+	# 		owner = { is_megacorp = yes }
+	# 	}
+	# 	text = job_executive_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_authoritarian = yes }
-			OR = {
-				owner = { has_valid_civic = civic_merchant_guilds }
-				owner = { has_valid_civic = civic_corporate_dominion }
-			}
-		}
-		text = job_merchant_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_authoritarian = yes }
+	# 		OR = {
+	# 			owner = { has_valid_civic = civic_merchant_guilds }
+	# 			owner = { has_valid_civic = civic_corporate_dominion }
+	# 		}
+	# 	}
+	# 	text = job_merchant_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_authoritarian = yes }
-			owner = { has_valid_civic = civic_aristocratic_elite }
-		}
-		text = job_noble_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_authoritarian = yes }
+	# 		owner = { has_valid_civic = civic_aristocratic_elite }
+	# 	}
+	# 	text = job_noble_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_authoritarian = yes }
-			owner = { has_valid_civic = civic_technocracy }
-		}
-		text = job_head_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_authoritarian = yes }
+	# 		owner = { has_valid_civic = civic_technocracy }
+	# 	}
+	# 	text = job_head_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_authoritarian = yes }
-			owner = { has_valid_civic = civic_exalted_priesthood }
-		}
-		text = job_high_priest_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_authoritarian = yes }
+	# 		owner = { has_valid_civic = civic_exalted_priesthood }
+	# 	}
+	# 	text = job_high_priest_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_authoritarian = yes }
-			NOT = { owner = { has_active_tradition = tr_psionics_psi_corps }}
-		}
-		text = job_enforcer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_authoritarian = yes }
+	# 		NOT = { owner = { has_active_tradition = tr_psionics_psi_corps }}
+	# 	}
+	# 	text = job_enforcer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_authoritarian = yes }
-			owner = { has_active_tradition = tr_psionics_psi_corps }
-		}
-		text = job_telepath_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_authoritarian = yes }
+	# 		owner = { has_active_tradition = tr_psionics_psi_corps }
+	# 	}
+	# 	text = job_telepath_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_authoritarian = yes }
-		}
-		text = job_clerk_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_authoritarian = yes }
+	# 	}
+	# 	text = job_clerk_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.1800 }

--- a/common/buildings/pw_living_spire.txt
+++ b/common/buildings/pw_living_spire.txt
@@ -358,11 +358,15 @@ pw_building_living_spire_1 = {
 	triggered_desc = {
 		text = pw_planet_wonder_lb
 	}
+	# inline_script = {
+	# 	script = jobs/pw/politician_add
+	# 	OWNER_CONDITION = ""
+	# 	SHOW_JOB_STEWARD_EFFECT_DESC = yes
+	# 	AMOUNT = 1
+	# }
 	inline_script = {
-		script = jobs/pw/politician_add
-		OWNER_CONDITION = ""
-		SHOW_JOB_STEWARD_EFFECT_DESC = yes
-		AMOUNT = 1
+		script = jobs/politician_add
+		AMOUNT = 100
 	}
 	#Medical Worker
 	triggered_planet_modifier = {
@@ -379,7 +383,7 @@ pw_building_living_spire_1 = {
 					has_ascension_perk = ap_the_flesh_is_weak
 					has_origin = origin_cybernetic_creed
 				}
-				has_toxic_baths = no
+				# has_toxic_baths = no
 			}
 		}
 		modifier = {
@@ -404,27 +408,27 @@ pw_building_living_spire_1 = {
 		}
 	}
 	#Spa Attendants (1) (only mutagenic spas)
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				# NOT = {
-				# 	has_ascension_perk = ap_synthetic_evolution
-				# }
-				nor = {
-					has_ascension_perk = ap_synthetic_evolution
-					has_origin = origin_synthetic_fertility
-					is_individual_machine = yes
-					has_ascension_perk = ap_the_flesh_is_weak
-					has_origin = origin_cybernetic_creed
-				}
-				has_toxic_baths = yes
-			}
-		}
-		modifier = {
-			job_bath_attendant_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			# NOT = {
+	# 			# 	has_ascension_perk = ap_synthetic_evolution
+	# 			# }
+	# 			nor = {
+	# 				has_ascension_perk = ap_synthetic_evolution
+	# 				has_origin = origin_synthetic_fertility
+	# 				is_individual_machine = yes
+	# 				has_ascension_perk = ap_the_flesh_is_weak
+	# 				has_origin = origin_cybernetic_creed
+	# 			}
+	# 			has_toxic_baths = yes
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_bath_attendant_add = 100
+	# 	}
+	# }
 	triggered_planet_modifier = {
 		potential = {
 			exists = owner
@@ -483,94 +487,94 @@ pw_building_living_spire_1 = {
 	#		text = job_executive_effect_desc
 	#	}
 	#Medical Worker
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				# NOT = {
-				# 	has_ascension_perk = ap_synthetic_evolution
-				# }
-				nor = {
-					has_ascension_perk = ap_synthetic_evolution
-					has_origin = origin_synthetic_fertility
-					is_individual_machine = yes
-					has_ascension_perk = ap_the_flesh_is_weak
-					has_origin = origin_cybernetic_creed
-				}
-				has_toxic_baths = no
-			}
-		}
-		text = job_healthcare_effect_desc
-	}
-	#Roboticist
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				# has_ascension_perk = ap_synthetic_evolution
-				OR = {
-					has_ascension_perk = ap_synthetic_evolution
-					has_origin = origin_synthetic_fertility
-					is_individual_machine = yes
-				}
-			}
-		}
-		text = job_roboticist_effect_desc
-	}
-	#Bath Attendant
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				# NOT = {
-				# 	has_ascension_perk = ap_synthetic_evolution
-				# }
-				nor = {
-					has_ascension_perk = ap_synthetic_evolution
-					has_origin = origin_synthetic_fertility
-					is_individual_machine = yes
-					has_ascension_perk = ap_the_flesh_is_weak
-					has_origin = origin_cybernetic_creed
-				}
-				has_toxic_baths = yes
-			}
-		}
-		text = job_toxic_baths_effect_desc
-	}
-	#Augmentor
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				or = {
-					has_ascension_perk = ap_the_flesh_is_weak
-					has_origin = origin_cybernetic_creed
-				}
-			}
-			is_cyborg_empire = yes
-		}
-		text = job_augmentor_growth_effect_desc
-	}
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				or = {
-					has_ascension_perk = ap_the_flesh_is_weak
-					has_origin = origin_cybernetic_creed
-				}
-			}
-			is_cyborg_empire = no
-		}
-		text = job_augmentor_research_effect_desc
-	}
-	#Clerk
-	triggered_desc = {
-		trigger = {
-			exists = owner
-		}
-		text = job_clerk_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			# NOT = {
+	# 			# 	has_ascension_perk = ap_synthetic_evolution
+	# 			# }
+	# 			nor = {
+	# 				has_ascension_perk = ap_synthetic_evolution
+	# 				has_origin = origin_synthetic_fertility
+	# 				is_individual_machine = yes
+	# 				has_ascension_perk = ap_the_flesh_is_weak
+	# 				has_origin = origin_cybernetic_creed
+	# 			}
+	# 			has_toxic_baths = no
+	# 		}
+	# 	}
+	# 	text = job_healthcare_effect_desc
+	# }
+	# #Roboticist
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			# has_ascension_perk = ap_synthetic_evolution
+	# 			OR = {
+	# 				has_ascension_perk = ap_synthetic_evolution
+	# 				has_origin = origin_synthetic_fertility
+	# 				is_individual_machine = yes
+	# 			}
+	# 		}
+	# 	}
+	# 	text = job_roboticist_effect_desc
+	# }
+	# #Bath Attendant
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			# NOT = {
+	# 			# 	has_ascension_perk = ap_synthetic_evolution
+	# 			# }
+	# 			nor = {
+	# 				has_ascension_perk = ap_synthetic_evolution
+	# 				has_origin = origin_synthetic_fertility
+	# 				is_individual_machine = yes
+	# 				has_ascension_perk = ap_the_flesh_is_weak
+	# 				has_origin = origin_cybernetic_creed
+	# 			}
+	# 			has_toxic_baths = yes
+	# 		}
+	# 	}
+	# 	text = job_toxic_baths_effect_desc
+	# }
+	# #Augmentor
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			or = {
+	# 				has_ascension_perk = ap_the_flesh_is_weak
+	# 				has_origin = origin_cybernetic_creed
+	# 			}
+	# 		}
+	# 		is_cyborg_empire = yes
+	# 	}
+	# 	text = job_augmentor_growth_effect_desc
+	# }
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			or = {
+	# 				has_ascension_perk = ap_the_flesh_is_weak
+	# 				has_origin = origin_cybernetic_creed
+	# 			}
+	# 		}
+	# 		is_cyborg_empire = no
+	# 	}
+	# 	text = job_augmentor_research_effect_desc
+	# }
+	# #Clerk
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 	}
+	# 	text = job_clerk_effect_desc
+	# }
 	ai_weight = {
 		weight = 60
 		modifier = {
@@ -809,11 +813,15 @@ pw_building_living_spire_2 = {
 	triggered_desc = {
 		text = pw_planet_wonder_lb
 	}
+	# inline_script = {
+	# 	script = jobs/pw/politician_add
+	# 	OWNER_CONDITION = ""
+	# 	SHOW_JOB_STEWARD_EFFECT_DESC = yes
+	# 	AMOUNT = 1
+	# }
 	inline_script = {
-		script = jobs/pw/politician_add
-		OWNER_CONDITION = ""
-		SHOW_JOB_STEWARD_EFFECT_DESC = yes
-		AMOUNT = 1
+		script = jobs/politician_add
+		AMOUNT = 100
 	}
 	#Merchant
 	triggered_planet_modifier = {
@@ -1076,34 +1084,34 @@ pw_building_living_spire_2 = {
 		ASSEMBLY_MULT = 0.1
 	}
 	#Clerk
-	triggered_desc = {
-		trigger = {
-			exists = owner
-		}
-		text = job_clerk_effect_desc
-	}
-	#Enforcer
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			NOT = {
-				owner = {
-					has_active_tradition = tr_psionics_psi_corps
-				}
-			}
-		}
-		text = job_enforcer_effect_desc
-	}
-	#Telepath
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				has_active_tradition = tr_psionics_psi_corps
-			}
-		}
-		text = job_telepath_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 	}
+	# 	text = job_clerk_effect_desc
+	# }
+	# #Enforcer
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		NOT = {
+	# 			owner = {
+	# 				has_active_tradition = tr_psionics_psi_corps
+	# 			}
+	# 		}
+	# 	}
+	# 	text = job_enforcer_effect_desc
+	# }
+	# #Telepath
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			has_active_tradition = tr_psionics_psi_corps
+	# 		}
+	# 	}
+	# 	text = job_telepath_effect_desc
+	# }
 	#Entertainer
 	# triggered_desc = {
 	# 	trigger = {
@@ -1365,11 +1373,15 @@ pw_building_living_spire_3 = {
 	triggered_desc = {
 		text = pw_planet_wonder_lb
 	}
+	# inline_script = {
+	# 	script = jobs/pw/politician_add
+	# 	OWNER_CONDITION = ""
+	# 	SHOW_JOB_STEWARD_EFFECT_DESC = yes
+	# 	AMOUNT = 2
+	# }
 	inline_script = {
-		script = jobs/pw/politician_add
-		OWNER_CONDITION = ""
-		SHOW_JOB_STEWARD_EFFECT_DESC = yes
-		AMOUNT = 2
+		script = jobs/politician_add
+		AMOUNT = 200
 	}
 	#Merchant
 	triggered_planet_modifier = {
@@ -1594,34 +1606,34 @@ pw_building_living_spire_3 = {
 		ASSEMBLY_MULT = 0.15
 	}
 	#Clerk
-	triggered_desc = {
-		trigger = {
-			exists = owner
-		}
-		text = job_clerk_effect_desc
-	}
-	#Enforcer
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			NOT = {
-				owner = {
-					has_active_tradition = tr_psionics_psi_corps
-				}
-			}
-		}
-		text = job_enforcer_effect_desc
-	}
-	#Telepath
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				has_active_tradition = tr_psionics_psi_corps
-			}
-		}
-		text = job_telepath_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 	}
+	# 	text = job_clerk_effect_desc
+	# }
+	# #Enforcer
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		NOT = {
+	# 			owner = {
+	# 				has_active_tradition = tr_psionics_psi_corps
+	# 			}
+	# 		}
+	# 	}
+	# 	text = job_enforcer_effect_desc
+	# }
+	# #Telepath
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			has_active_tradition = tr_psionics_psi_corps
+	# 		}
+	# 	}
+	# 	text = job_telepath_effect_desc
+	# }
 	#Entertainer
 	# triggered_desc = {
 	# 	trigger = {

--- a/common/buildings/pw_manufacturing_buildings.txt
+++ b/common/buildings/pw_manufacturing_buildings.txt
@@ -310,41 +310,41 @@ pw_building_mantle_crucible = {
 		text = pw_planet_wonder_lb
 	}
 
-	inline_script = {
-		script = jobs/pw/foundry_effect_desc
-		OWNER_CONDITION = ""
-	}
+	# inline_script = {
+	# 	script = jobs/pw/foundry_effect_desc
+	# 	OWNER_CONDITION = ""
+	# }
 
-	inline_script = {
-		script = jobs/pw/factory_effect_desc
-		OWNER_CONDITION = "country_uses_consumer_goods = yes"
-	}
+	# inline_script = {
+	# 	script = jobs/pw/factory_effect_desc
+	# 	OWNER_CONDITION = "country_uses_consumer_goods = yes"
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { country_uses_consumer_goods = no }
-		}
-		text = job_miner_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { country_uses_consumer_goods = no }
+	# 	}
+	# 	text = job_miner_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_mining_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_mining_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-			owner = { country_uses_consumer_goods = no }
-		}
-		text = job_mining_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 		owner = { country_uses_consumer_goods = no }
+	# 	}
+	# 	text = job_mining_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.1300 }
@@ -632,26 +632,26 @@ pw_building_titan_forge = {
 		text = pw_empire_unique_lb
 	}
 
-	inline_script = {
-		script = jobs/pw/foundry_effect_desc
-		OWNER_CONDITION = ""
-	}
+	# inline_script = {
+	# 	script = jobs/pw/foundry_effect_desc
+	# 	OWNER_CONDITION = ""
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_politician_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_politician_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_replicator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_replicator_effect_desc
+	# }
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
@@ -919,37 +919,37 @@ pw_building_industrial_hearth = {
 		text = pw_empire_unique_lb
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_pw_poly_artisan_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_pw_poly_artisan_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_merchant_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_merchant_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_pw_poly_artisan_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_pw_poly_artisan_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_replicator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_replicator_effect_desc
+	# }
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.

--- a/common/buildings/pw_research_buildings.txt
+++ b/common/buildings/pw_research_buildings.txt
@@ -299,63 +299,63 @@ pw_building_particle_supercollider = {
 	}
 
 	#Regular Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_head_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_head_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_pw_researcher_particle_supercollider_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_pw_researcher_particle_supercollider_effect_desc
+	# }
 
-	#Hive Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_brain_drone_effect_desc
-	}
+	# #Hive Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_brain_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_pw_brain_drone_particle_supercollider_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_pw_brain_drone_particle_supercollider_effect_desc
+	# }
 
-	#Machine Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_calculator_effect_desc
-	}
+	# #Machine Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_calculator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_pw_calculator_particle_supercollider_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_pw_calculator_particle_supercollider_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.200 }
@@ -408,7 +408,8 @@ pw_building_particle_supercollider = {
 				has_active_building = building_research_lab_3
 				has_district = district_hab_science
 				has_district = district_rw_science
-				num_pops_with_job_tag = {
+				# num_pops_with_job_tag = {
+				total_workforce_with_job_tag = {
 					value > 0
 					tags = { research }
 				}
@@ -651,63 +652,63 @@ pw_building_interdimensional_collider = {
 	}
 
 	#Regular Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_head_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_head_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_pw_researcher_particle_supercollider_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_pw_researcher_particle_supercollider_effect_desc
+	# }
 
-	#Hive Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_brain_drone_effect_desc
-	}
+	# #Hive Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_brain_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_pw_brain_drone_particle_supercollider_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_pw_brain_drone_particle_supercollider_effect_desc
+	# }
 
-	#Machine Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_calculator_effect_desc
-	}
+	# #Machine Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_calculator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_pw_calculator_particle_supercollider_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_pw_calculator_particle_supercollider_effect_desc
+	# }
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
@@ -1093,79 +1094,79 @@ pw_building_domed_city = {
 	}
 
 	#Regular Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_head_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_head_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_pw_researcher_domed_city_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_pw_researcher_domed_city_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_pw_domed_city_test_subject_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_pw_domed_city_test_subject_effect_desc
+	# }
 
-	#Hive Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_brain_drone_effect_desc
-	}
+	# #Hive Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_brain_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_pw_brain_drone_domed_city_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_pw_brain_drone_domed_city_effect_desc
+	# }
 
-	#Machine Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_calculator_effect_desc
-	}
+	# #Machine Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_calculator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_pw_calculator_domed_city_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_pw_calculator_domed_city_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_pw_domed_city_subject_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_pw_domed_city_subject_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.300 }
@@ -1535,79 +1536,79 @@ pw_building_secluded_sector = {
 	}
 
 	#Regular Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_head_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_head_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_pw_researcher_domed_city_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_pw_researcher_domed_city_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_pw_domed_city_test_subject_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_pw_domed_city_test_subject_effect_desc
+	# }
 
-	#Hive Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_brain_drone_effect_desc
-	}
+	# #Hive Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_brain_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_pw_brain_drone_domed_city_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_pw_brain_drone_domed_city_effect_desc
+	# }
 
-	#Machine Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_calculator_effect_desc
-	}
+	# #Machine Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_calculator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_pw_calculator_domed_city_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_pw_calculator_domed_city_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_pw_domed_city_subject_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_pw_domed_city_subject_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.300 }
@@ -1892,79 +1893,79 @@ pw_building_psionic_observatory = {
 	}
 
 	#Regular Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_head_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_head_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_pw_researcher_domed_city_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_pw_researcher_domed_city_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_pw_domed_city_test_subject_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_pw_domed_city_test_subject_effect_desc
+	# }
 
-	#Hive Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_brain_drone_effect_desc
-	}
+	# #Hive Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_brain_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_pw_brain_drone_domed_city_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_pw_brain_drone_domed_city_effect_desc
+	# }
 
-	#Machine Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_calculator_effect_desc
-	}
+	# #Machine Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_calculator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_pw_calculator_domed_city_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_pw_calculator_domed_city_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_pw_domed_city_subject_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_pw_domed_city_subject_drone_effect_desc
+	# }
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
@@ -2346,63 +2347,63 @@ pw_building_abyssal_crater_test_site = {
 	}
 
 	#Regular Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_head_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_head_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_pw_researcher_abyssal_crater_test_site_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_pw_researcher_abyssal_crater_test_site_effect_desc
+	# }
 
-	#Hive Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_brain_drone_effect_desc
-	}
+	# #Hive Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_brain_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_pw_brain_drone_abyssal_crater_test_site_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_pw_brain_drone_abyssal_crater_test_site_effect_desc
+	# }
 
-	#Machine Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_calculator_effect_desc
-	}
+	# #Machine Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_calculator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_pw_calculator_abyssal_crater_test_site_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_pw_calculator_abyssal_crater_test_site_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.400 }
@@ -2770,63 +2771,63 @@ pw_building_abyssal_crater_test_site_habitat = {
 	}
 
 	#Regular Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_head_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_head_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_pw_researcher_abyssal_crater_test_site_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_pw_researcher_abyssal_crater_test_site_effect_desc
+	# }
 
-	#Hive Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_brain_drone_effect_desc
-	}
+	# #Hive Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_brain_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_pw_brain_drone_abyssal_crater_test_site_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_pw_brain_drone_abyssal_crater_test_site_effect_desc
+	# }
 
-	#Machine Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_calculator_effect_desc
-	}
+	# #Machine Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_calculator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_pw_calculator_abyssal_crater_test_site_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_pw_calculator_abyssal_crater_test_site_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.400 }
@@ -3108,63 +3109,63 @@ pw_building_metal_vivarium = {
 	}
 
 	#Regular Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_head_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_head_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_researcher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_researcher_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_pw_researcher_abyssal_crater_test_site_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_pw_researcher_abyssal_crater_test_site_effect_desc
+	# }
 
-	#Hive Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_brain_drone_effect_desc
-	}
+	# #Hive Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_brain_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_pw_brain_drone_abyssal_crater_test_site_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_pw_brain_drone_abyssal_crater_test_site_effect_desc
+	# }
 
-	#Machine Jobs
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_calculator_effect_desc
-	}
+	# #Machine Jobs
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_calculator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_pw_calculator_abyssal_crater_test_site_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_pw_calculator_abyssal_crater_test_site_effect_desc
+	# }
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
@@ -3444,17 +3445,17 @@ pw_building_grand_archive = {
 		text = pw_building_grand_archive_tooltip
 	}
 
-	triggered_desc = {
-		text = job_pw_grand_archivist_effect_desc
-	}
+	# triggered_desc = {
+	# 	text = job_pw_grand_archivist_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { has_country_flag = pw_grand_archive_holoarchive_master_archivist_appointed }
-		}
-		text = job_pw_master_archivist_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { has_country_flag = pw_grand_archive_holoarchive_master_archivist_appointed }
+	# 	}
+	# 	text = job_pw_master_archivist_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.1600 }

--- a/common/buildings/pw_resource_buildings.txt
+++ b/common/buildings/pw_resource_buildings.txt
@@ -226,37 +226,37 @@ pw_building_erebus_project = {
 		text = pw_erebus_project_jobs_add_gestalt
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_pw_mining_director_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_pw_mining_director_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_pw_mining_coordinator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_pw_mining_coordinator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_miner_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_miner_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_mining_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_mining_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.500 }
@@ -577,53 +577,53 @@ pw_building_erebus_fracking_plant = {
 		text = pw_erebus_project_jobs_add_gestalt
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_pw_mining_director_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_pw_mining_director_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_pw_mining_coordinator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_pw_mining_coordinator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_chemist_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_chemist_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_chemist_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_chemist_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_miner_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_miner_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_mining_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_mining_drone_effect_desc
+	# }
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
@@ -911,37 +911,37 @@ pw_building_helios_tower = {
 		text = pw_helios_tower_jobs_add_gestalt
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_pw_energy_director_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_pw_energy_director_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_pw_energy_coordinator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_pw_energy_coordinator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_technician_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_technician_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_technician_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_technician_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.600 }
@@ -1254,53 +1254,53 @@ pw_building_helios_translucent_obelisk = {
 		text = pw_helios_tower_jobs_add_gestalt
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_pw_energy_director_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_pw_energy_director_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_pw_energy_coordinator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_pw_energy_coordinator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_translucer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_translucer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_translucer_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_translucer_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_technician_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_technician_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_technician_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_technician_drone_effect_desc
+	# }
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
@@ -1631,68 +1631,68 @@ pw_building_demetrius_fields = {
 		text = pw_demetrius_fields_jobs_add_gestalt
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_pw_agriculture_director_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_pw_agriculture_director_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_pw_food_coordinator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_pw_food_coordinator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-			OR = {
-				owner = { is_anglers_empire = no }
-				AND = {
-					owner = { is_anglers_empire = yes }
-					NOT = { is_wet = yes }
-				}
-			}
-		}
-		text = job_farmer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 		OR = {
+	# 			owner = { is_anglers_empire = no }
+	# 			AND = {
+	# 				owner = { is_anglers_empire = yes }
+	# 				NOT = { is_wet = yes }
+	# 			}
+	# 		}
+	# 	}
+	# 	text = job_farmer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				is_regular_empire = yes
-				is_anglers_empire = yes
-			}
-			is_wet = yes
-		}
-		text = job_aqu_angler_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_regular_empire = yes
+	# 			is_anglers_empire = yes
+	# 		}
+	# 		is_wet = yes
+	# 	}
+	# 	text = job_aqu_angler_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				is_regular_empire = yes
-				is_anglers_empire = yes
-			}
-			is_wet = yes
-		}
-		text = job_pearl_diver_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_regular_empire = yes
+	# 			is_anglers_empire = yes
+	# 		}
+	# 		is_wet = yes
+	# 	}
+	# 	text = job_pearl_diver_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_agri_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_agri_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.700 }
@@ -2050,84 +2050,84 @@ pw_building_demetrius_chemical_garden = {
 		text = pw_demetrius_fields_jobs_add_gestalt
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_pw_agriculture_director_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_pw_agriculture_director_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_pw_food_coordinator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_pw_food_coordinator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		text = job_gas_refiner_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 	}
+	# 	text = job_gas_refiner_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_gas_refiner_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_gas_refiner_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-			OR = {
-				owner = { is_anglers_empire = no }
-				AND = {
-					owner = { is_anglers_empire = yes }
-					NOT = { is_wet = yes }
-				}
-			}
-		}
-		text = job_farmer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 		OR = {
+	# 			owner = { is_anglers_empire = no }
+	# 			AND = {
+	# 				owner = { is_anglers_empire = yes }
+	# 				NOT = { is_wet = yes }
+	# 			}
+	# 		}
+	# 	}
+	# 	text = job_farmer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				is_regular_empire = yes
-				is_anglers_empire = yes
-			}
-			is_wet = yes
-		}
-		text = job_aqu_angler_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_regular_empire = yes
+	# 			is_anglers_empire = yes
+	# 		}
+	# 		is_wet = yes
+	# 	}
+	# 	text = job_aqu_angler_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				is_regular_empire = yes
-				is_anglers_empire = yes
-			}
-			is_wet = yes
-		}
-		text = job_pearl_diver_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_regular_empire = yes
+	# 			is_anglers_empire = yes
+	# 		}
+	# 		is_wet = yes
+	# 	}
+	# 	text = job_pearl_diver_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_agri_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_agri_drone_effect_desc
+	# }
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.

--- a/common/buildings/pw_trade_buildings.txt
+++ b/common/buildings/pw_trade_buildings.txt
@@ -147,7 +147,7 @@ pw_building_space_elevator = {
 		}
 		modifier = {
 			job_pw_logistics_drone_add = 500
-			job_maintenance_drone_add = 300
+			# job_maintenance_drone_add = 300
 			job_patrol_drone_add = 100
 			job_coordinator_add = 100
 			planet_amenities_no_happiness_mult = 0.05
@@ -162,7 +162,7 @@ pw_building_space_elevator = {
 		}
 		modifier = {
 			job_pw_logistics_drone_add = 500
-			job_maintenance_drone_add = 300
+			# job_maintenance_drone_add = 300
 			job_patrol_drone_add = 100
 			job_coordinator_add = 100
 			planet_amenities_no_happiness_mult = 0.05
@@ -348,69 +348,69 @@ pw_building_space_elevator = {
 		text = pw_planet_wonder_lb
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_merchant_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_merchant_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = no }
-		}
-		text = job_clerk_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = no }
+	# 	}
+	# 	text = job_clerk_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = no }
-		}
-		text = job_enforcer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = no }
+	# 	}
+	# 	text = job_enforcer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_pw_logistics_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_pw_logistics_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		text = job_synapse_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	text = job_synapse_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_coordinator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_coordinator_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_maintenance_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_maintenance_drone_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_patrol_drone_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_patrol_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.100 }
@@ -625,6 +625,7 @@ pw_building_department_of_xenoeconomics = {
 			job_politician_add = 200 # merchant
 	# 		job_manager_add = 200
 			job_clerk_add = 200
+			job_bureaucrat_add = 200
 		}
 	}
 	triggered_desc = {
@@ -638,14 +639,14 @@ pw_building_department_of_xenoeconomics = {
 	inline_script = {
 		script = jobs/pw/politician_add
 		OWNER_CONDITION = "is_megacorp = yes"
-		SHOW_JOB_STEWARD_EFFECT_DESC = no
+		# SHOW_JOB_STEWARD_EFFECT_DESC = no
 		AMOUNT = 1
 	}
-	inline_script = {
-		script = jobs/pw/culture_worker_add
-		OWNER_CONDITION = "is_megacorp = yes"
-		AMOUNT = 2
-	}
+	# inline_script = {
+	# 	script = jobs/pw/culture_worker_add
+	# 	OWNER_CONDITION = "is_megacorp = yes"
+	# 	AMOUNT = 2
+	# }
 
 	#Stability Bonus
 	triggered_planet_modifier = {
@@ -688,13 +689,13 @@ pw_building_department_of_xenoeconomics = {
 	# }
 
 	#Merchant
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		text = job_merchant_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = yes }
+	# 	}
+	# 	text = job_merchant_effect_desc
+	# }
 
 	# #Manager
 	# triggered_desc = {
@@ -706,13 +707,13 @@ pw_building_department_of_xenoeconomics = {
 	# }
 
 	#Clerk
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_regular_empire = no }
-		}
-		text = job_clerk_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_regular_empire = no }
+	# 	}
+	# 	text = job_clerk_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.2600 }

--- a/common/buildings/pw_unity_buildings.txt
+++ b/common/buildings/pw_unity_buildings.txt
@@ -137,25 +137,30 @@ pw_building_pavilion_of_wonders = {
 	#Reminder: Cannot be Gestalt!
 
 	#Administrator
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_megacorp = no }
-		}
-		modifier = {
-			job_politician_add = 100
-		}
+	planet_modifier = {
+		job_politician_add = 100
+		job_entertainer_add = 200
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_megacorp = yes }
-		}
-		modifier = {
-			job_politician_add = 100 # merchant
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = no }
+	# 	}
+	# 	modifier = {
+	# 		job_politician_add = 100
+	# 	}
+	# }
+
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = yes }
+	# 	}
+	# 	modifier = {
+	# 		job_politician_add = 100 # merchant
+	# 	}
+	# }
 
 	# #Culture Workers
 	# triggered_planet_modifier = {
@@ -222,29 +227,29 @@ pw_building_pavilion_of_wonders = {
 	# }
 
 	#Entertainers
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				NOT = { has_valid_civic = civic_warrior_culture }
-			}
-		}
-		modifier = {
-			job_entertainer_add = 200
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			NOT = { has_valid_civic = civic_warrior_culture }
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_entertainer_add = 200
+	# 	}
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		modifier = {
-			job_duelist_add = 200
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			has_valid_civic = civic_warrior_culture
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_duelist_add = 200
+	# 	}
+	# }
 
 	#Stability
 	triggered_planet_modifier = {
@@ -284,21 +289,21 @@ pw_building_pavilion_of_wonders = {
 		text = pw_planet_wonder_lb
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_megacorp = no }
-		}
-		text = job_politician_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = no }
+	# 	}
+	# 	text = job_politician_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_megacorp = yes }
-		}
-		text = job_merchant_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = yes }
+	# 	}
+	# 	text = job_merchant_effect_desc
+	# }
 
 	# triggered_desc = {
 	# 	trigger = {
@@ -335,25 +340,25 @@ pw_building_pavilion_of_wonders = {
 	# 	text = job_pw_tourist_effect_desc
 	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				NOT = { has_valid_civic = civic_warrior_culture }
-			}
-		}
-		text = job_entertainer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			NOT = { has_valid_civic = civic_warrior_culture }
+	# 		}
+	# 	}
+	# 	text = job_entertainer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		text = job_duelist_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			has_valid_civic = civic_warrior_culture
+	# 		}
+	# 	}
+	# 	text = job_duelist_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.1400 }
@@ -594,25 +599,30 @@ pw_building_fair_of_worlds = {
 	#Reminder: Cannot be Gestalt and must be xenophile!
 
 	#Administrator
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_megacorp = no }
-		}
-		modifier = {
-			job_politician_add = 100
-		}
+	planet_modifier = {
+		job_politician_add = 100
+		job_entertainer_add = 300
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_megacorp = yes }
-		}
-		modifier = {
-			job_politician_add = 100 # merchant
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = no }
+	# 	}
+	# 	modifier = {
+	# 		job_politician_add = 100
+	# 	}
+	# }
+
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = yes }
+	# 	}
+	# 	modifier = {
+	# 		job_politician_add = 100 # merchant
+	# 	}
+	# }
 
 	# #Culture Workers
 	# triggered_planet_modifier = {
@@ -679,29 +689,29 @@ pw_building_fair_of_worlds = {
 	# }
 
 	#Entertainers
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				NOT = { has_valid_civic = civic_warrior_culture }
-			}
-		}
-		modifier = {
-			job_entertainer_add = 300
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			NOT = { has_valid_civic = civic_warrior_culture }
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_entertainer_add = 300
+	# 	}
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		modifier = {
-			job_duelist_add = 300
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			has_valid_civic = civic_warrior_culture
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_duelist_add = 300
+	# 	}
+	# }
 
 	#Curators of Diversity (Envoys, max 5)
 	triggered_planet_modifier = {
@@ -913,21 +923,21 @@ pw_building_fair_of_worlds = {
 		text = pw_building_fair_of_worlds_tooltip
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_megacorp = no }
-		}
-		text = job_politician_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = no }
+	# 	}
+	# 	text = job_politician_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_megacorp = yes }
-		}
-		text = job_merchant_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = yes }
+	# 	}
+	# 	text = job_merchant_effect_desc
+	# }
 
 	# triggered_desc = {
 	# 	trigger = {
@@ -964,41 +974,41 @@ pw_building_fair_of_worlds = {
 	# 	text = job_pw_tourist_effect_desc
 	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				NOT = { has_valid_civic = civic_warrior_culture }
-			}
-		}
-		text = job_entertainer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			NOT = { has_valid_civic = civic_warrior_culture }
+	# 		}
+	# 	}
+	# 	text = job_entertainer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		text = job_duelist_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			has_valid_civic = civic_warrior_culture
+	# 		}
+	# 	}
+	# 	text = job_duelist_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_xenophile = yes }
-			owner = {
-				OR = {
-					has_federation = yes
-					any_envoy = {
-						has_envoy_task = { task = improve_relations }
-					}
-				}
-			}
-		}
-		text = job_pw_diversity_curator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_xenophile = yes }
+	# 		owner = {
+	# 			OR = {
+	# 				has_federation = yes
+	# 				any_envoy = {
+	# 					has_envoy_task = { task = improve_relations }
+	# 				}
+	# 			}
+	# 		}
+	# 	}
+	# 	text = job_pw_diversity_curator_effect_desc
+	# }
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
@@ -1225,25 +1235,30 @@ pw_building_museum_of_the_grotesque = {
 	#Reminder: Cannot be Gestalt and must be xenophobe!
 
 	#Administrator
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_megacorp = no }
-		}
-		modifier = {
-			job_politician_add = 100
-		}
+	planet_modifier = {
+		job_politician_add = 100
+		job_entertainer_add = 300
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_megacorp = yes }
-		}
-		modifier = {
-			job_politician_add = 100 # merchant
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = no }
+	# 	}
+	# 	modifier = {
+	# 		job_politician_add = 100
+	# 	}
+	# }
+
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = yes }
+	# 	}
+	# 	modifier = {
+	# 		job_politician_add = 100 # merchant
+	# 	}
+	# }
 
 	# #Culture Workers
 	# triggered_planet_modifier = {
@@ -1310,29 +1325,29 @@ pw_building_museum_of_the_grotesque = {
 	# }
 
 	#Entertainers
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				NOT = { has_valid_civic = civic_warrior_culture }
-			}
-		}
-		modifier = {
-			job_entertainer_add = 300
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			NOT = { has_valid_civic = civic_warrior_culture }
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_entertainer_add = 300
+	# 	}
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		modifier = {
-			job_duelist_add = 300
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			has_valid_civic = civic_warrior_culture
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_duelist_add = 300
+	# 	}
+	# }
 
 	#Curators of Degeneracy (Envoys, max 5)
 	triggered_planet_modifier = {
@@ -1602,21 +1617,21 @@ pw_building_museum_of_the_grotesque = {
 		text = pw_building_museum_of_the_grotesque_tooltip_no_diplomacy
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_megacorp = no }
-		}
-		text = job_politician_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = no }
+	# 	}
+	# 	text = job_politician_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_megacorp = yes }
-		}
-		text = job_merchant_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = yes }
+	# 	}
+	# 	text = job_merchant_effect_desc
+	# }
 
 	# triggered_desc = {
 	# 	trigger = {
@@ -1653,43 +1668,43 @@ pw_building_museum_of_the_grotesque = {
 	# 	text = job_pw_tourist_effect_desc
 	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				NOT = { has_valid_civic = civic_warrior_culture }
-			}
-		}
-		text = job_entertainer_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			NOT = { has_valid_civic = civic_warrior_culture }
+	# 		}
+	# 	}
+	# 	text = job_entertainer_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		text = job_duelist_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			has_valid_civic = civic_warrior_culture
+	# 		}
+	# 	}
+	# 	text = job_duelist_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				OR = {
-					is_at_war = yes
-					has_valid_civic = civic_fanatic_purifiers
-					has_valid_civic = civic_inwards_perfection
-					count_rival_country = { count > 0 }
-					any_envoy = {
-						has_envoy_task = { task = harm_relations }
-					}
-				}
-			}
-		}
-		text = job_pw_degeneracy_curator_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			OR = {
+	# 				is_at_war = yes
+	# 				has_valid_civic = civic_fanatic_purifiers
+	# 				has_valid_civic = civic_inwards_perfection
+	# 				count_rival_country = { count > 0 }
+	# 				any_envoy = {
+	# 					has_envoy_task = { task = harm_relations }
+	# 				}
+	# 			}
+	# 		}
+	# 	}
+	# 	text = job_pw_degeneracy_curator_effect_desc
+	# }
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
@@ -1999,10 +2014,10 @@ pw_building_holy_reliquary = {
 	# 	}
 	# }
 
-	inline_script = {
-		script = jobs/pw/bureaucrat_effect_desc
-		OWNER_CONDITION = "is_spiritualist = yes"
-	}
+	# inline_script = {
+	# 	script = jobs/pw/bureaucrat_effect_desc
+	# 	OWNER_CONDITION = "is_spiritualist = yes"
+	# }
 
 	#Prosperity preacher
 	triggered_planet_modifier = {
@@ -2052,24 +2067,24 @@ pw_building_holy_reliquary = {
 		text = pw_building_holy_reliquary_tooltip
 	}
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { has_country_flag = pw_holy_reliquary_relic_keeper_appointed }
-		}
-		text = job_pw_relic_keeper_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { has_country_flag = pw_holy_reliquary_relic_keeper_appointed }
+	# 	}
+	# 	text = job_pw_relic_keeper_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				is_spiritualist = yes
-				not = { has_origin = origin_cybernetic_creed }
-			}
-		}
-		text = job_high_priest_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_spiritualist = yes
+	# 			not = { has_origin = origin_cybernetic_creed }
+	# 		}
+	# 	}
+	# 	text = job_high_priest_effect_desc
+	# }
 
 	# triggered_desc = {
 	# 	trigger = {
@@ -2081,57 +2096,57 @@ pw_building_holy_reliquary = {
 	# 	text = job_priest_effect_desc
 	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				is_spiritualist = yes
-				has_origin = origin_cybernetic_creed
-			}
-		}
-		text = job_technophant_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_spiritualist = yes
+	# 			has_origin = origin_cybernetic_creed
+	# 		}
+	# 	}
+	# 	text = job_technophant_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			OR = {
-				owner = { has_valid_civic = civic_death_cult }
-				owner = { has_valid_civic = civic_death_cult_corporate }
-			}
-		}
-		text = job_death_priest_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		OR = {
+	# 			owner = { has_valid_civic = civic_death_cult }
+	# 			owner = { has_valid_civic = civic_death_cult_corporate }
+	# 		}
+	# 	}
+	# 	text = job_death_priest_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			OR = {
-				owner = { has_valid_civic = civic_death_cult }
-				owner = { has_valid_civic = civic_death_cult_corporate }
-			}
-		}
-		text = job_mortal_initiate_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		OR = {
+	# 			owner = { has_valid_civic = civic_death_cult }
+	# 			owner = { has_valid_civic = civic_death_cult_corporate }
+	# 		}
+	# 	}
+	# 	text = job_mortal_initiate_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { has_valid_civic = civic_memorialist }
-		}
-		text = job_death_chronicler_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { has_valid_civic = civic_memorialist }
+	# 	}
+	# 	text = job_death_chronicler_effect_desc
+	# }
 
-	triggered_desc = {
-		trigger = {
-			exists = planet.branch_office_owner
-			has_holding = {
-				holding = building_temple_of_prosperity
-				owner = planet.branch_office_owner
-			}
-		}
-		text = job_preacher_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = planet.branch_office_owner
+	# 		has_holding = {
+	# 			holding = building_temple_of_prosperity
+	# 			owner = planet.branch_office_owner
+	# 		}
+	# 	}
+	# 	text = job_preacher_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.1500 }
@@ -2333,70 +2348,74 @@ pw_building_unhallowed_necropolis = {
 
 	#Regular Jobs (total: 7/5)
 	#High Priest/Technophant/Administrator/CEO
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_spiritualist = yes
-				not = { has_origin = origin_cybernetic_creed }
-			}
-		}
-		modifier = {
-			job_politician_add = 100 # high_priest
-		}
+	inline_script = {
+		script = jobs/politician_add
+		AMOUNT = 100
 	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_spiritualist = yes
+	# 			not = { has_origin = origin_cybernetic_creed }
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_politician_add = 100 # high_priest
+	# 	}
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_spiritualist = yes
-				has_origin = origin_cybernetic_creed
-			}
-		}
-		modifier = {
-			job_technophant_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_spiritualist = yes
+	# 			has_origin = origin_cybernetic_creed
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_technophant_add = 100
+	# 	}
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { is_spiritualist = no }
-			owner = { is_megacorp = no }
-		}
-		modifier = {
-			job_politician_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { is_spiritualist = no }
+	# 		owner = { is_megacorp = no }
+	# 	}
+	# 	modifier = {
+	# 		job_politician_add = 100
+	# 	}
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { is_spiritualist = no }
-			owner = { is_megacorp = yes }
-			owner = { is_worker_coop_empire = no }
-		}
-		modifier = {
-			job_politician_add = 100 # executive
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { is_spiritualist = no }
+	# 		owner = { is_megacorp = yes }
+	# 		owner = { is_worker_coop_empire = no }
+	# 	}
+	# 	modifier = {
+	# 		job_politician_add = 100 # executive
+	# 	}
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_gestalt = no
-				is_spiritualist = no
-				is_worker_coop_empire = yes
-			}
-		}
-		modifier = {
-			job_steward_add = 200
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_gestalt = no
+	# 			is_spiritualist = no
+	# 			is_worker_coop_empire = yes
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_steward_add = 200
+	# 	}
+	# }
 
 	#Tomb scholars (2)
 	triggered_planet_modifier = {
@@ -2448,85 +2467,94 @@ pw_building_unhallowed_necropolis = {
 	# 		job_manager_add = 200
 	# 	}
 	# }
-	inline_script = {
-		script = jobs/pw/death_chronicler_add
-		OWNER_CONDITION = "is_gestalt = no"
-		AMOUNT = 2
-	}
-
-	#Death Priests/Priests/Culture workers/Managers (2)
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			OR = {
-				owner = { has_valid_civic = civic_death_cult }
-				owner = { has_valid_civic = civic_death_cult_corporate }
-			}
-		}
-		modifier = {
-			job_bureaucrat_add = 200 # death_priest
-		}
-	}
-
-	# Note: if the owner is not spiritualist, this building is not destroyed but produce no job.
-	inline_script = {
-		script = jobs/pw/bureaucrat_add
-		OWNER_CONDITION = "is_spiritualist = yes is_death_cult_empire = no"
-		AMOUNT = 2
-	}
-
-	# triggered_planet_modifier = {
-	# 	potential = {
-	# 		exists = owner
-	# 		owner = { is_spiritualist = yes }
-	# 		NOT = { owner = { has_valid_civic = civic_death_cult }}
-	# 		NOT = { owner = { has_valid_civic = civic_death_cult_corporate }}
-	# 	}
-	# 	modifier = {
-	# 		job_bureaucrat_add = 200 # priest
-	# 	}
-	# }
-
 	triggered_planet_modifier = {
 		potential = {
 			exists = owner
 			owner = { is_gestalt = no }
-			owner = { is_megacorp = no }
-			owner = { is_spiritualist = no }
-			NOT = { owner = { has_valid_civic = civic_death_cult }}
-			NOT = { owner = { has_valid_civic = civic_death_cult_corporate }}
 		}
 		modifier = {
-			job_culture_worker_add = 200
+			job_bureaucrat_add = 400
 		}
 	}
+	# inline_script = {
+	# 	script = jobs/pw/death_chronicler_add
+	# 	OWNER_CONDITION = "is_gestalt = no"
+	# 	AMOUNT = 2
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_megacorp = yes }
-			owner = { is_spiritualist = no }
-			NOT = { owner = { has_valid_civic = civic_death_cult }}
-			NOT = { owner = { has_valid_civic = civic_death_cult_corporate }}
-			owner = { is_worker_coop_empire = no }
-		}
-		modifier = {
-			job_manager_add = 200
-		}
-	}
+	#Death Priests/Priests/Culture workers/Managers (2)
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		OR = {
+	# 			owner = { has_valid_civic = civic_death_cult }
+	# 			owner = { has_valid_civic = civic_death_cult_corporate }
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_bureaucrat_add = 200 # death_priest
+	# 	}
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_worker_coop_empire = yes
-				is_spiritualist = no
-			}
-		}
-		modifier = {
-			job_steward_add = 200
-		}
-	}
+	# # Note: if the owner is not spiritualist, this building is not destroyed but produce no job.
+	# inline_script = {
+	# 	script = jobs/pw/bureaucrat_add
+	# 	OWNER_CONDITION = "is_spiritualist = yes is_death_cult_empire = no"
+	# 	AMOUNT = 2
+	# }
+
+	# # triggered_planet_modifier = {
+	# # 	potential = {
+	# # 		exists = owner
+	# # 		owner = { is_spiritualist = yes }
+	# # 		NOT = { owner = { has_valid_civic = civic_death_cult }}
+	# # 		NOT = { owner = { has_valid_civic = civic_death_cult_corporate }}
+	# # 	}
+	# # 	modifier = {
+	# # 		job_bureaucrat_add = 200 # priest
+	# # 	}
+	# # }
+
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { is_megacorp = no }
+	# 		owner = { is_spiritualist = no }
+	# 		NOT = { owner = { has_valid_civic = civic_death_cult }}
+	# 		NOT = { owner = { has_valid_civic = civic_death_cult_corporate }}
+	# 	}
+	# 	modifier = {
+	# 		job_culture_worker_add = 200
+	# 	}
+	# }
+
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_megacorp = yes }
+	# 		owner = { is_spiritualist = no }
+	# 		NOT = { owner = { has_valid_civic = civic_death_cult }}
+	# 		NOT = { owner = { has_valid_civic = civic_death_cult_corporate }}
+	# 		owner = { is_worker_coop_empire = no }
+	# 	}
+	# 	modifier = {
+	# 		job_manager_add = 200
+	# 	}
+	# }
+
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_worker_coop_empire = yes
+	# 			is_spiritualist = no
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_steward_add = 200
+	# 	}
+	# }
 
 	#Gestalt Jobs (total: 7/5)
 	#Tomb surveyors (2)
@@ -2559,58 +2587,68 @@ pw_building_unhallowed_necropolis = {
 	triggered_planet_modifier = {
 		potential = {
 			exists = owner
-			OR = {
-				owner = { has_valid_civic = civic_hive_memorialist }
-				owner = { has_valid_civic = civic_machine_memorialist }
-			}
+			owner = { is_gestalt = yes }
 		}
 		modifier = {
-			job_chronicle_drone_add = 200
+			job_coordinator_add = 400
 		}
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-			owner = { NOT = { has_valid_civic = civic_hive_memorialist }}
-		}
-		modifier = {
-			job_coordinator_add = 200
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		OR = {
+	# 			owner = { has_valid_civic = civic_hive_memorialist }
+	# 			owner = { has_valid_civic = civic_machine_memorialist }
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_chronicle_drone_add = 200
+	# 	}
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-			owner = { NOT = { has_valid_civic = civic_machine_memorialist }}
-		}
-		modifier = {
-			job_evaluator_add = 200
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 		owner = { NOT = { has_valid_civic = civic_hive_memorialist }}
+	# 	}
+	# 	modifier = {
+	# 		job_coordinator_add = 200
+	# 	}
+	# }
+
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 		owner = { NOT = { has_valid_civic = civic_machine_memorialist }}
+	# 	}
+	# 	modifier = {
+	# 		job_evaluator_add = 200
+	# 	}
+	# }
 
 	#Evaluator/Synapse (2)
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		modifier = {
-			job_coordinator_add = 200
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_hive_empire = yes }
+	# 	}
+	# 	modifier = {
+	# 		job_coordinator_add = 200
+	# 	}
+	# }
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		modifier = {
-			job_evaluator_add = 200
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	modifier = {
+	# 		job_evaluator_add = 200
+	# 	}
+	# }
 
 	#Stability from ambition
 	triggered_planet_modifier = {
@@ -2639,100 +2677,100 @@ pw_building_unhallowed_necropolis = {
 	}
 
 	#High Priest
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				is_spiritualist = yes
-				not = { has_origin = origin_cybernetic_creed }
-			}
-		}
-		text = job_high_priest_effect_desc
-	}
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_spiritualist = yes
+	# 			not = { has_origin = origin_cybernetic_creed }
+	# 		}
+	# 	}
+	# 	text = job_high_priest_effect_desc
+	# }
 
-	#Technophant
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = {
-				is_spiritualist = yes
-				has_origin = origin_cybernetic_creed
-			}
-		}
-		text = job_technophant_effect_desc
-	}
+	# #Technophant
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = {
+	# 			is_spiritualist = yes
+	# 			has_origin = origin_cybernetic_creed
+	# 		}
+	# 	}
+	# 	text = job_technophant_effect_desc
+	# }
 
-	#Administrator
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { is_spiritualist = no }
-			owner = { is_megacorp = no }
-		}
-		text = job_politician_effect_desc
-	}
+	# #Administrator
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { is_spiritualist = no }
+	# 		owner = { is_megacorp = no }
+	# 	}
+	# 	text = job_politician_effect_desc
+	# }
 
-	#CEO
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { is_spiritualist = no }
-			owner = { is_megacorp = yes }
-			owner = { is_worker_coop_empire = no }
-		}
-		text = job_executive_effect_desc
-	}
+	# #CEO
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { is_spiritualist = no }
+	# 		owner = { is_megacorp = yes }
+	# 		owner = { is_worker_coop_empire = no }
+	# 	}
+	# 	text = job_executive_effect_desc
+	# }
 
-	#Tomb Scholar
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			OR = {
-				merg_is_nuked = yes
-				is_planet_class = pc_relic
-			}
-		}
-		text = job_pw_tomb_scholar_effect_desc
-	}
+	# #Tomb Scholar
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		OR = {
+	# 			merg_is_nuked = yes
+	# 			is_planet_class = pc_relic
+	# 		}
+	# 	}
+	# 	text = job_pw_tomb_scholar_effect_desc
+	# }
 
-	#Tomb surveyor
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-			OR = {
-				merg_is_nuked = yes
-				is_planet_class = pc_relic
-			}
-		}
-		text = job_pw_tomb_surveyor_effect_desc
-	}
+	# #Tomb surveyor
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 		OR = {
+	# 			merg_is_nuked = yes
+	# 			is_planet_class = pc_relic
+	# 		}
+	# 	}
+	# 	text = job_pw_tomb_surveyor_effect_desc
+	# }
 
-	#Death Chronicler
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { has_valid_civic = civic_memorialist }
-		}
-		text = job_death_chronicler_effect_desc
-	}
+	# #Death Chronicler
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { has_valid_civic = civic_memorialist }
+	# 	}
+	# 	text = job_death_chronicler_effect_desc
+	# }
 
-	#Death Priests
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			OR = {
-				owner = { has_valid_civic = civic_death_cult }
-				owner = { has_valid_civic = civic_death_cult_corporate }
-			}
-		}
-		text = job_death_priest_effect_desc
-	}
+	# #Death Priests
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		OR = {
+	# 			owner = { has_valid_civic = civic_death_cult }
+	# 			owner = { has_valid_civic = civic_death_cult_corporate }
+	# 		}
+	# 	}
+	# 	text = job_death_priest_effect_desc
+	# }
 
 	# #Priest
 	# triggered_desc = {
@@ -2746,85 +2784,85 @@ pw_building_unhallowed_necropolis = {
 	# 	text = job_priest_effect_desc
 	# }
 
-	inline_script = {
-		script = jobs/pw/bureaucrat_effect_desc
-		OWNER_CONDITION = "is_spiritualist = yes"
-	}
+	# inline_script = {
+	# 	script = jobs/pw/bureaucrat_effect_desc
+	# 	OWNER_CONDITION = "is_spiritualist = yes"
+	# }
 
-	#Culture Worker
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { is_spiritualist = no }
-			owner = { is_megacorp = no }
-			OR = {
-				owner = { NOT = { has_valid_civic = civic_memorialist }}
-				owner = { NOT = { has_valid_civic = civic_death_cult }}
-			}
-		}
-		text = job_bureaucrat_effect_desc
-	}
+	# #Culture Worker
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { is_spiritualist = no }
+	# 		owner = { is_megacorp = no }
+	# 		OR = {
+	# 			owner = { NOT = { has_valid_civic = civic_memorialist }}
+	# 			owner = { NOT = { has_valid_civic = civic_death_cult }}
+	# 		}
+	# 	}
+	# 	text = job_bureaucrat_effect_desc
+	# }
 
-	#Manager
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = no }
-			owner = { is_megacorp = yes }
-			owner = { is_worker_coop_empire = no }
-		}
-		text = job_manager_effect_desc
-	}
+	# #Manager
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = no }
+	# 		owner = { is_megacorp = yes }
+	# 		owner = { is_worker_coop_empire = no }
+	# 	}
+	# 	text = job_manager_effect_desc
+	# }
 
-	#Steward
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_worker_coop_empire = yes }
-		}
-		text = job_steward_effect_desc
-	}
+	# #Steward
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_worker_coop_empire = yes }
+	# 	}
+	# 	text = job_steward_effect_desc
+	# }
 
-	#Hunter-Seeker drone
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_patrol_drone_effect_desc
-	}
+	# #Hunter-Seeker drone
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_patrol_drone_effect_desc
+	# }
 
-	#Chronicle Drone
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-			OR = {
-				owner = { has_valid_civic = civic_hive_memorialist }
-				owner = { has_valid_civic = civic_machine_memorialist }
-			}
-		}
-		text = job_chronicle_drone_effect_desc
-	}
+	# #Chronicle Drone
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 		OR = {
+	# 			owner = { has_valid_civic = civic_hive_memorialist }
+	# 			owner = { has_valid_civic = civic_machine_memorialist }
+	# 		}
+	# 	}
+	# 	text = job_chronicle_drone_effect_desc
+	# }
 
-	#Evaluator
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		text = job_evaluator_effect_desc
-	}
+	# #Evaluator
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_machine_empire = yes }
+	# 	}
+	# 	text = job_evaluator_effect_desc
+	# }
 
-	#Synapse
-	triggered_desc = {
-		trigger = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		text = job_synapse_drone_effect_desc
-	}
+	# #Synapse
+	# triggered_desc = {
+	# 	trigger = {
+	# 		exists = owner
+	# 		owner = { is_gestalt = yes }
+	# 	}
+	# 	text = job_synapse_drone_effect_desc
+	# }
 
 	on_built = {
 		planet_event = { id = pw_wonder.2400 }

--- a/common/deposits/pw_infrastructure_deposits.txt
+++ b/common/deposits/pw_infrastructure_deposits.txt
@@ -415,13 +415,14 @@ pw_d_infrastructure_local_administration = {
 		planet_jobs_specialist_produces_mult = 0.10
 		planet_jobs_unity_produces_mult = 0.10
 		planet_jobs_upkeep_mult = 0.10
+		job_bureaucrat_add = 100
 	}
 
-	inline_script = {
-		script = jobs/pw/bureaucrat_add
-		OWNER_CONDITION = ""
-		AMOUNT = 1
-	}
+	# inline_script = {
+	# 	script = jobs/pw/bureaucrat_add
+	# 	OWNER_CONDITION = ""
+	# 	AMOUNT = 1
+	# }
 #	#Bureaucrat
 #	triggered_planet_modifier = {
 #		potential = {
@@ -476,13 +477,14 @@ pw_d_infrastructure_distributed_education = {
 		planet_jobs_specialist_produces_mult = 0.15
 		planet_jobs_unity_produces_mult = 0.15
 		planet_jobs_upkeep_mult = 0.15
+		job_bureaucrat_add = 100
 	}
 
-	inline_script = {
-		script = jobs/pw/bureaucrat_add
-		OWNER_CONDITION = ""
-		AMOUNT = 1
-	}
+	# inline_script = {
+	# 	script = jobs/pw/bureaucrat_add
+	# 	OWNER_CONDITION = ""
+	# 	AMOUNT = 1
+	# }
 #	#Bureaucrat
 #	triggered_planet_modifier = {
 #		potential = {
@@ -538,13 +540,15 @@ pw_d_infrastructure_arts_installations = {
 		planet_jobs_unity_produces_mult = 0.20
 		planet_amenities_add = 200
 		planet_jobs_upkeep_mult = 0.20
+		job_bureaucrat_add = 100
+		job_entertainer_add = 100
 	}
 
-	inline_script = {
-		script = jobs/pw/bureaucrat_add
-		OWNER_CONDITION = ""
-		AMOUNT = 1
-	}
+	# inline_script = {
+	# 	script = jobs/pw/bureaucrat_add
+	# 	OWNER_CONDITION = ""
+	# 	AMOUNT = 1
+	# }
 #	#Bureaucrat
 #	triggered_planet_modifier = {
 #		potential = {
@@ -568,30 +572,30 @@ pw_d_infrastructure_arts_installations = {
 #	}
 
 	#Entertainers
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				NOT = { has_valid_civic = civic_warrior_culture }
-			}
-		}
-		modifier = {
-			job_entertainer_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			NOT = { has_valid_civic = civic_warrior_culture }
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_entertainer_add = 100
+	# 	}
+	# }
 
-	#Duelist
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		modifier = {
-			job_duelist_add = 100
-		}
-	}
+	# #Duelist
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			has_valid_civic = civic_warrior_culture
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_duelist_add = 100
+	# 	}
+	# }
 }
 
 # Public Markets
@@ -1055,7 +1059,7 @@ pw_d_infrastructure_palatial_physicians = {
 			exists = owner
 			owner = {
 				NOT = { has_ascension_perk = ap_synthetic_evolution }
-				has_toxic_baths = no
+				# has_toxic_baths = no
 			}
 		}
 		modifier = {
@@ -1077,18 +1081,18 @@ pw_d_infrastructure_palatial_physicians = {
 	}
 
 	#Spa Attendants (only mutagenic spas)
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				NOT = { has_ascension_perk = ap_synthetic_evolution }
-				has_toxic_baths = yes
-			}
-		}
-		modifier = {
-			job_bath_attendant_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			NOT = { has_ascension_perk = ap_synthetic_evolution }
+	# 			has_toxic_baths = yes
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_bath_attendant_add = 100
+	# 	}
+	# }
 }
 
 # City Defenders
@@ -1119,7 +1123,7 @@ pw_d_infrastructure_city_defenders = {
 			exists = owner
 			owner = {
 				NOT = { has_ascension_perk = ap_synthetic_evolution }
-				has_toxic_baths = no
+				# has_toxic_baths = no
 			}
 		}
 		modifier = {
@@ -1141,18 +1145,18 @@ pw_d_infrastructure_city_defenders = {
 	}
 
 	#Spa Attendants (only mutagenic spas)
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				NOT = { has_ascension_perk = ap_synthetic_evolution }
-				has_toxic_baths = yes
-			}
-		}
-		modifier = {
-			job_bath_attendant_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			NOT = { has_ascension_perk = ap_synthetic_evolution }
+	# 			has_toxic_baths = yes
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_bath_attendant_add = 100
+	# 	}
+	# }
 
 	#Enforcer
 	triggered_planet_modifier = {
@@ -1209,7 +1213,7 @@ pw_d_infrastructure_crisis_bunker = {
 			exists = owner
 			owner = {
 				NOT = { has_ascension_perk = ap_synthetic_evolution }
-				has_toxic_baths = no
+				# has_toxic_baths = no
 			}
 		}
 		modifier = {
@@ -1231,18 +1235,18 @@ pw_d_infrastructure_crisis_bunker = {
 	}
 
 	#Spa Attendants (only mutagenic spas)
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				NOT = { has_ascension_perk = ap_synthetic_evolution }
-				has_toxic_baths = yes
-			}
-		}
-		modifier = {
-			job_bath_attendant_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			NOT = { has_ascension_perk = ap_synthetic_evolution }
+	# 			has_toxic_baths = yes
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_bath_attendant_add = 100
+	# 	}
+	# }
 
 	#Enforcer
 	triggered_planet_modifier = {
@@ -1300,7 +1304,7 @@ pw_d_infrastructure_personal_guardian = {
 			exists = owner
 			owner = {
 				NOT = { has_ascension_perk = ap_synthetic_evolution }
-				has_toxic_baths = no
+				# has_toxic_baths = no
 			}
 		}
 		modifier = {
@@ -1322,18 +1326,18 @@ pw_d_infrastructure_personal_guardian = {
 	}
 
 	#Spa Attendants (only mutagenic spas)
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				NOT = { has_ascension_perk = ap_synthetic_evolution }
-				has_toxic_baths = yes
-			}
-		}
-		modifier = {
-			job_bath_attendant_add = 100
-		}
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		exists = owner
+	# 		owner = {
+	# 			NOT = { has_ascension_perk = ap_synthetic_evolution }
+	# 			has_toxic_baths = yes
+	# 		}
+	# 	}
+	# 	modifier = {
+	# 		job_bath_attendant_add = 100
+	# 	}
+	# }
 
 	#Enforcer
 	triggered_planet_modifier = {
@@ -1380,23 +1384,24 @@ pw_d_infrastructure_central_of_disinformation = {
 	planet_modifier = {
 		planet_jobs_specialist_produces_mult = 0.05
 		planet_jobs_upkeep_mult = 0.05
-	}
-
-	#Entertainer
-	triggered_planet_modifier = {
-		potential = {
-			owner = { NOT = { has_valid_civic = civic_warrior_culture }}
-		}
 		job_entertainer_add = 100
 	}
 
-	#Duelist
-	triggered_planet_modifier = {
-		potential = {
-			owner = { has_valid_civic = civic_warrior_culture }
-		}
-		job_duelist_add = 100
-	}
+	#Entertainer
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		owner = { NOT = { has_valid_civic = civic_warrior_culture }}
+	# 	}
+	# 	job_entertainer_add = 100
+	# }
+
+	# #Duelist
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		owner = { has_valid_civic = civic_warrior_culture }
+	# 	}
+	# 	job_duelist_add = 100
+	# }
 }
 
 # Center of Justice
@@ -1424,23 +1429,24 @@ pw_d_infrastructure_center_of_justice = {
 		planet_jobs_specialist_produces_mult = 0.10
 		planet_crime_add = -10
 		planet_jobs_upkeep_mult = 0.10
-	}
-
-	#Entertainer
-	triggered_planet_modifier = {
-		potential = {
-			owner = { NOT = { has_valid_civic = civic_warrior_culture }}
-		}
 		job_entertainer_add = 100
 	}
 
-	#Duelist
-	triggered_planet_modifier = {
-		potential = {
-			owner = { has_valid_civic = civic_warrior_culture }
-		}
-		job_duelist_add = 100
-	}
+	#Entertainer
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		owner = { NOT = { has_valid_civic = civic_warrior_culture }}
+	# 	}
+	# 	job_entertainer_add = 100
+	# }
+
+	# #Duelist
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		owner = { has_valid_civic = civic_warrior_culture }
+	# 	}
+	# 	job_duelist_add = 100
+	# }
 }
 
 # Central Treasury
@@ -1470,23 +1476,24 @@ pw_d_infrastructure_central_treasury = {
 		planet_crime_add = -15
 		planet_traders_produces_mult = 0.15
 		planet_jobs_upkeep_mult = 0.05
-	}
-
-	#Entertainer
-	triggered_planet_modifier = {
-		potential = {
-			owner = { NOT = { has_valid_civic = civic_warrior_culture }}
-		}
 		job_entertainer_add = 100
 	}
 
-	#Duelist
-	triggered_planet_modifier = {
-		potential = {
-			owner = { has_valid_civic = civic_warrior_culture }
-		}
-		job_duelist_add = 100
-	}
+	#Entertainer
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		owner = { NOT = { has_valid_civic = civic_warrior_culture }}
+	# 	}
+	# 	job_entertainer_add = 100
+	# }
+
+	# #Duelist
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		owner = { has_valid_civic = civic_warrior_culture }
+	# 	}
+	# 	job_duelist_add = 100
+	# }
 }
 
 # Galactic Bureau (Requires galactic Modeling Bureau somewhere)
@@ -1516,13 +1523,15 @@ pw_d_infrastructure_galactic_bureau = {
 		planet_crime_add = -20
 		planet_traders_produces_mult = 0.20
 		planet_jobs_upkeep_mult = 0.05
+		job_bureaucrat_add = 100
+		job_entertainer_add = 100
 	}
 
-	inline_script = {
-		script = jobs/pw/bureaucrat_add
-		OWNER_CONDITION = ""
-		AMOUNT = 1
-	}
+	# inline_script = {
+	# 	script = jobs/pw/bureaucrat_add
+	# 	OWNER_CONDITION = ""
+	# 	AMOUNT = 1
+	# }
 #	#Bureaucrat
 #	triggered_planet_modifier = {
 #		potential = {
@@ -1546,20 +1555,20 @@ pw_d_infrastructure_galactic_bureau = {
 #	}
 
 	#Entertainer
-	triggered_planet_modifier = {
-		potential = {
-			owner = { NOT = { has_valid_civic = civic_warrior_culture }}
-		}
-		job_entertainer_add = 100
-	}
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		owner = { NOT = { has_valid_civic = civic_warrior_culture }}
+	# 	}
+	# 	job_entertainer_add = 100
+	# }
 
-	#Duelist
-	triggered_planet_modifier = {
-		potential = {
-			owner = { has_valid_civic = civic_warrior_culture }
-		}
-		job_duelist_add = 100
-	}
+	# #Duelist
+	# triggered_planet_modifier = {
+	# 	potential = {
+	# 		owner = { has_valid_civic = civic_warrior_culture }
+	# 	}
+	# 	job_duelist_add = 100
+	# }
 }
 
 # Central Council: Ambassador Chambers
@@ -1854,7 +1863,7 @@ pw_d_integration_CARE_facility = {
 	planet_modifier = {
 		planet_housing_add = 200
 		job_patrol_drone_add = 100
-		job_maintenance_drone_add = 200
+		# job_maintenance_drone_add = 200
 		planet_amenities_mult = 0.15
 		planet_pops_upkeep_mult = 0.10
 	}

--- a/common/deposits/pw_planetary_deposits.txt
+++ b/common/deposits/pw_planetary_deposits.txt
@@ -7,10 +7,11 @@ pw_d_ancient_cornucopia = {
 	#Can't occur naturally
 	potential = { always = no }
 
-	triggered_planet_modifier = {
+	# triggered_planet_modifier = {
+	planet_modifier = {
 		planet_jobs_food_produces_mult = 0.05
-		district_farming_max = 1
-		mult = value:natural_desposit_district_amount_multiplier
+		district_farming_max_add = 1
+		# mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -64,10 +65,11 @@ pw_d_ancient_solar_tower = {
 	#Can't occur naturally
 	potential = { always = no }
 
-	triggered_planet_modifier = {
+	# triggered_planet_modifier = {
+	planet_modifier = {
 		planet_jobs_energy_produces_mult = 0.05
-		district_generator_max = 1
-		mult = value:natural_desposit_district_amount_multiplier
+		district_generator_max_add = 1
+		# mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -99,10 +101,11 @@ pw_d_ancient_mining_project = {
 	#Can't occur naturally
 	potential = { always = no }
 
-	triggered_planet_modifier = {
+	planet_modifier = {
+	# triggered_planet_modifier = {
 		planet_jobs_minerals_produces_mult = 0.05
-		district_mining_max = 1
-		mult = value:natural_desposit_district_amount_multiplier
+		district_mining_max_add = 1
+		# mult = value:natural_desposit_district_amount_multiplier
 	}
 
 	triggered_planet_modifier = {
@@ -480,7 +483,8 @@ pw_d_guardian_angel_arena = {
 			}
 		}
 		modifier = {
-			job_duelist_add = 100
+			# job_duelist_add = 100
+			job_entertainer_add = 100
 		}
 	}
 }

--- a/common/inline_scripts/jobs/pw/bureaucrat_add.txt
+++ b/common/inline_scripts/jobs/pw/bureaucrat_add.txt
@@ -13,8 +13,8 @@ triggered_planet_modifier = {
 		exists = owner
 		owner = {
 			$OWNER_CONDITION$
-			is_spiritualist = no
-			is_megacorp = no
+			# is_spiritualist = no
+			# is_megacorp = no
 		}
 	}
 	job_bureaucrat_add = 100
@@ -22,74 +22,74 @@ triggered_planet_modifier = {
 }
 
 #Manager
-triggered_planet_modifier = {
-	potential = {
-		exists = owner
-		owner = {
-			$OWNER_CONDITION$
-			is_spiritualist = no
-			is_megacorp = yes
-			is_worker_coop_empire = no
-		}
-	}
-	job_manager_add = 100
-	mult = $AMOUNT$
-}
+# triggered_planet_modifier = {
+# 	potential = {
+# 		exists = owner
+# 		owner = {
+# 			$OWNER_CONDITION$
+# 			is_spiritualist = no
+# 			is_megacorp = yes
+# 			is_worker_coop_empire = no
+# 		}
+# 	}
+# 	job_manager_add = 100
+# 	mult = $AMOUNT$
+# }
 
-#Steward
-triggered_planet_modifier = {
-	potential = {
-		exists = owner
-		owner = {
-			$OWNER_CONDITION$
-			is_spiritualist = no
-			is_worker_coop_empire = yes
-		}
-	}
-	job_steward_add = 100
-	mult = $AMOUNT$
-}
+# #Steward
+# triggered_planet_modifier = {
+# 	potential = {
+# 		exists = owner
+# 		owner = {
+# 			$OWNER_CONDITION$
+# 			is_spiritualist = no
+# 			is_worker_coop_empire = yes
+# 		}
+# 	}
+# 	job_steward_add = 100
+# 	mult = $AMOUNT$
+# }
 
-#Priest
-triggered_planet_modifier = {
-	potential = {
-		exists = owner
-		owner = {
-			$OWNER_CONDITION$
-			is_spiritualist = yes
-			is_megacorp = no
-			NOT = { has_origin = origin_cybernetic_creed }
-		}
-	}
-	job_bureaucrat_add = 100 # priest
-	mult = $AMOUNT$
-}
+# #Priest
+# triggered_planet_modifier = {
+# 	potential = {
+# 		exists = owner
+# 		owner = {
+# 			$OWNER_CONDITION$
+# 			is_spiritualist = yes
+# 			is_megacorp = no
+# 			NOT = { has_origin = origin_cybernetic_creed }
+# 		}
+# 	}
+# 	job_bureaucrat_add = 100 # priest
+# 	mult = $AMOUNT$
+# }
 
-#Preacher
-triggered_planet_modifier = {
-	potential = {
-		exists = owner
-		owner = {
-			$OWNER_CONDITION$
-			is_spiritualist = yes
-			is_megacorp = yes
-			NOT = { has_origin = origin_cybernetic_creed }
-		}
-	}
-	job_preacher_add = 100
-	mult = $AMOUNT$
-}
+# #Preacher
+# triggered_planet_modifier = {
+# 	potential = {
+# 		exists = owner
+# 		owner = {
+# 			$OWNER_CONDITION$
+# 			is_spiritualist = yes
+# 			is_megacorp = yes
+# 			NOT = { has_origin = origin_cybernetic_creed }
+# 		}
+# 	}
+# 	job_preacher_add = 100
+# 	mult = $AMOUNT$
+# }
 
-#Haruspex
-triggered_planet_modifier = {
-	potential = {
-		exists = owner
-		owner = {
-			$OWNER_CONDITION$
-			is_spiritualist = yes
-			has_origin = origin_cybernetic_creed
-		}
-	}
-	job_haruspex_add = 100
-	mult = $AMOUNT$
-}
+# #Haruspex
+# triggered_planet_modifier = {
+# 	potential = {
+# 		exists = owner
+# 		owner = {
+# 			$OWNER_CONDITION$
+# 			is_spiritualist = yes
+# 			has_origin = origin_cybernetic_creed
+# 		}
+# 	}
+# 	job_haruspex_add = 100
+# 	mult = $AMOUNT$
+# }

--- a/common/inline_scripts/jobs/pw/death_chronicler_add_pavilion.txt
+++ b/common/inline_scripts/jobs/pw/death_chronicler_add_pavilion.txt
@@ -3,86 +3,90 @@
 #	script = jobs/pw/death_chronicler_add_pavilion
 #	AMOUNT = 1
 #}
+planet_modifier = {
+	job_bureaucrat_per_pop = @pw_job_per_25_pop
+	job_bureaucrat_add = $AMOUNT$
+}
 # Note: memorialist will have job_culture_worker_per_pop and job_death_chronicler_add.
-triggered_planet_modifier = {
-	potential = {
-		exists = owner
-		owner = { is_megacorp = no }
-	}
-	modifier = {
-		job_culture_worker_per_pop = @pw_job_per_25_pop
-	}
-}
+# triggered_planet_modifier = {
+# 	potential = {
+# 		exists = owner
+# 		owner = { is_megacorp = no }
+# 	}
+# 	modifier = {
+# 		job_culture_worker_per_pop = @pw_job_per_25_pop
+# 	}
+# }
 
-triggered_planet_modifier = {
-	potential = {
-		exists = owner
-		owner = {
-			is_megacorp = yes
-			is_worker_coop_empire = no
-		}
-	}
-	modifier = {
-		job_manager_per_pop = @pw_job_per_25_pop
-	}
-}
+# triggered_planet_modifier = {
+# 	potential = {
+# 		exists = owner
+# 		owner = {
+# 			is_megacorp = yes
+# 			is_worker_coop_empire = no
+# 		}
+# 	}
+# 	modifier = {
+# 		job_manager_per_pop = @pw_job_per_25_pop
+# 	}
+# }
 
-triggered_planet_modifier = {
-	potential = {
-		exists = owner
-		owner = {
-			is_worker_coop_empire = yes
-		}
-	}
-	modifier = {
-		job_steward_per_pop = @pw_job_per_25_pop
-	}
-}
+# triggered_planet_modifier = {
+# 	potential = {
+# 		exists = owner
+# 		owner = {
+# 			is_worker_coop_empire = yes
+# 		}
+# 	}
+# 	modifier = {
+# 		job_steward_per_pop = @pw_job_per_25_pop
+# 	}
+# }
 
-inline_script = {
-	script = jobs/pw/death_chronicler_add
-	OWNER_CONDITION = ""
-	AMOUNT = "$AMOUNT$"
-}
+# inline_script = {
+# 	script = jobs/pw/death_chronicler_add
+# 	OWNER_CONDITION = ""
+# 	AMOUNT = "$AMOUNT$"
+# }
 
 #triggered_desc
-triggered_desc = {
-	trigger = {
-		exists = owner
-		owner = {
-			is_megacorp = no
-		}
-	}
-	text = job_bureaucrat_effect_desc
-}
+# triggered_desc = {
+# 	trigger = {
+# 		exists = owner
+# 		owner = {
+# 			is_megacorp = no
+# 		}
+# 	}
+# 	text = job_bureaucrat_effect_desc
+# }
 
-triggered_desc = {
-	trigger = {
-		exists = owner
-		owner = {
-			is_megacorp = yes
-			is_worker_coop_empire = no
-		}
-	}
-	text = job_manager_effect_desc
-}
+# triggered_desc = {
+# 	trigger = {
+# 		exists = owner
+# 		owner = {
+# 			is_megacorp = yes
+# 			is_worker_coop_empire = no
+# 		}
+# 	}
+# 	text = job_manager_effect_desc
+# }
 
-triggered_desc = {
-	trigger = {
-		exists = owner
-		owner = {
-			is_worker_coop_empire = yes
-		}
-	}
-	text = job_steward_effect_desc
-}
+# triggered_desc = {
+# 	trigger = {
+# 		exists = owner
+# 		owner = {
+# 			is_worker_coop_empire = yes
+# 		}
+# 	}
+# 	text = job_steward_effect_desc
+# }
 
-triggered_desc = {
-	trigger = {
-		exists = owner
-		owner = {
-			has_valid_civic = civic_memorialist
-		}
-	}
-	text = job_death_chronicler_effect_desc
-}
+# triggered_desc = {
+# 	trigger = {
+# 		exists = owner
+# 		owner = {
+# 			has_valid_civic = civic_memorialist
+# 		}
+# 	}
+# 	text = job_death_chronicler_effect_desc
+# }

--- a/common/inline_scripts/jobs/pw/living_spire_AP_jobs_add.txt
+++ b/common/inline_scripts/jobs/pw/living_spire_AP_jobs_add.txt
@@ -18,7 +18,7 @@ triggered_planet_modifier = {
 				has_origin = origin_synthetic_fertility
 				is_individual_machine = yes
 			}
-			has_toxic_baths = no
+			# has_toxic_baths = no
 		}
 	}
 	job_healthcare_add = 100
@@ -26,58 +26,58 @@ triggered_planet_modifier = {
 }
 
 # No Ascension Path / Mind over matter / Engineered Evolution
-triggered_desc = {
-	trigger = {
-		exists = owner
-		owner = {
-			nor = {
-				has_ascension_perk = ap_synthetic_evolution
-				has_origin = origin_synthetic_fertility
-				is_individual_machine = yes
-				has_ascension_perk = ap_the_flesh_is_weak
-				has_origin = origin_cybernetic_creed
-			}
-			has_toxic_baths = no
-		}
-	}
-	text = job_healthcare_effect_desc
-}
+# triggered_desc = {
+# 	trigger = {
+# 		exists = owner
+# 		owner = {
+# 			nor = {
+# 				has_ascension_perk = ap_synthetic_evolution
+# 				has_origin = origin_synthetic_fertility
+# 				is_individual_machine = yes
+# 				has_ascension_perk = ap_the_flesh_is_weak
+# 				has_origin = origin_cybernetic_creed
+# 			}
+# 			has_toxic_baths = no
+# 		}
+# 	}
+# 	text = job_healthcare_effect_desc
+# }
 
 #Spa Attendants (only mutagenic spas) (No Ascension Path)
-triggered_planet_modifier = {
-	potential = {
-		exists = owner
-		owner = {
-			has_ascension_path = no
-			NOR = {
-				has_origin = origin_cybernetic_creed
-				has_origin = origin_shroudwalker_apprentice
-				has_origin = origin_synthetic_fertility
-				is_individual_machine = yes
-			}
-			has_toxic_baths = yes
-		}
-	}
-	job_bath_attendant_add = 100
-	mult = $JOB_AMOUNT$
-}
+# triggered_planet_modifier = {
+# 	potential = {
+# 		exists = owner
+# 		owner = {
+# 			has_ascension_path = no
+# 			NOR = {
+# 				has_origin = origin_cybernetic_creed
+# 				has_origin = origin_shroudwalker_apprentice
+# 				has_origin = origin_synthetic_fertility
+# 				is_individual_machine = yes
+# 			}
+# 			has_toxic_baths = yes
+# 		}
+# 	}
+# 	job_bath_attendant_add = 100
+# 	mult = $JOB_AMOUNT$
+# }
 
-triggered_desc = {
-	trigger = {
-		exists = owner
-		owner = {
-			has_ascension_path = no
-			NOR = {
-				has_origin = origin_cybernetic_creed
-				has_origin = origin_shroudwalker_apprentice
-				has_origin = origin_synthetic_fertility
-				is_individual_machine = yes
-			}
-			has_toxic_baths = yes
-		}
-	}
-	text = job_toxic_baths_effect_desc
-}
+# triggered_desc = {
+# 	trigger = {
+# 		exists = owner
+# 		owner = {
+# 			has_ascension_path = no
+# 			NOR = {
+# 				has_origin = origin_cybernetic_creed
+# 				has_origin = origin_shroudwalker_apprentice
+# 				has_origin = origin_synthetic_fertility
+# 				is_individual_machine = yes
+# 			}
+# 			has_toxic_baths = yes
+# 		}
+# 	}
+# 	text = job_toxic_baths_effect_desc
+# }
 
 #Mind over matter
 triggered_planet_modifier = {
@@ -127,33 +127,33 @@ triggered_planet_modifier = {
 	}
 }
 
-triggered_desc = {
-	trigger = {
-		exists = owner
-		owner = {
-			or = {
-				has_ascension_perk = ap_the_flesh_is_weak
-				has_origin = origin_cybernetic_creed
-			}
-		}
-		is_cyborg_empire = yes
-	}
-	text = job_augmentor_growth_effect_desc
-}
+# triggered_desc = {
+# 	trigger = {
+# 		exists = owner
+# 		owner = {
+# 			or = {
+# 				has_ascension_perk = ap_the_flesh_is_weak
+# 				has_origin = origin_cybernetic_creed
+# 			}
+# 		}
+# 		is_cyborg_empire = yes
+# 	}
+# 	text = job_augmentor_growth_effect_desc
+# }
 
-triggered_desc = {
-	trigger = {
-		exists = owner
-		owner = {
-			or = {
-				has_ascension_perk = ap_the_flesh_is_weak
-				has_origin = origin_cybernetic_creed
-			}
-		}
-		is_cyborg_empire = no
-	}
-	text = job_augmentor_research_effect_desc
-}
+# triggered_desc = {
+# 	trigger = {
+# 		exists = owner
+# 		owner = {
+# 			or = {
+# 				has_ascension_perk = ap_the_flesh_is_weak
+# 				has_origin = origin_cybernetic_creed
+# 			}
+# 		}
+# 		is_cyborg_empire = no
+# 	}
+# 	text = job_augmentor_research_effect_desc
+# }
 
 #Synthetic Evolution
 triggered_planet_modifier = {
@@ -174,16 +174,16 @@ triggered_planet_modifier = {
 }
 
 #Roboticist
-triggered_desc = {
-	trigger = {
-		exists = owner
-		owner = {
-			or = {
-				has_ascension_perk = ap_synthetic_evolution
-				has_origin = origin_synthetic_fertility
-				is_individual_machine = yes
-			}
-		}
-	}
-	text = job_roboticist_effect_desc
-}
+# triggered_desc = {
+# 	trigger = {
+# 		exists = owner
+# 		owner = {
+# 			or = {
+# 				has_ascension_perk = ap_synthetic_evolution
+# 				has_origin = origin_synthetic_fertility
+# 				is_individual_machine = yes
+# 			}
+# 		}
+# 	}
+# 	text = job_roboticist_effect_desc
+# }

--- a/common/inline_scripts/jobs/pw/politician_add.txt
+++ b/common/inline_scripts/jobs/pw/politician_add.txt
@@ -12,49 +12,50 @@ triggered_planet_modifier = {
 		exists = owner
 		owner = {
 			$OWNER_CONDITION$
-			is_megacorp = no
+			# is_megacorp = no
+			is_worker_coop_empire = no
 		}
 	}
 	job_politician_add = 100
 	mult = $AMOUNT$
 }
 
-triggered_desc = {
-	trigger = {
-		exists = owner
-		owner = {
-			$OWNER_CONDITION$
-			is_megacorp = no
-		}
-	}
-	text = job_politician_effect_desc
-}
+# triggered_desc = {
+# 	trigger = {
+# 		exists = owner
+# 		owner = {
+# 			$OWNER_CONDITION$
+# 			is_megacorp = no
+# 		}
+# 	}
+# 	text = job_politician_effect_desc
+# }
 
-#Executive
-triggered_planet_modifier = {
-	potential = {
-		exists = owner
-		owner = {
-			$OWNER_CONDITION$
-			is_megacorp = yes
-			is_worker_coop_empire = no
-		}
-	}
-	job_executive_add = 100
-	mult = $AMOUNT$
-}
+# #Executive
+# triggered_planet_modifier = {
+# 	potential = {
+# 		exists = owner
+# 		owner = {
+# 			$OWNER_CONDITION$
+# 			is_megacorp = yes
+# 			is_worker_coop_empire = no
+# 		}
+# 	}
+# 	job_executive_add = 100
+# 	mult = $AMOUNT$
+# }
 
-triggered_desc = {
-	trigger = {
-		exists = owner
-		owner = {
-			$OWNER_CONDITION$
-			is_megacorp = yes
-			is_worker_coop_empire = no
-		}
-	}
-	text = job_executive_effect_desc
-}
+# triggered_desc = {
+# 	trigger = {
+# 		exists = owner
+# 		owner = {
+# 			$OWNER_CONDITION$
+# 			is_megacorp = yes
+# 			is_worker_coop_empire = no
+# 		}
+# 	}
+# 	text = job_executive_effect_desc
+# }
 
 #Steward
 triggered_planet_modifier = {
@@ -62,23 +63,23 @@ triggered_planet_modifier = {
 		exists = owner
 		owner = {
 			$OWNER_CONDITION$
-			is_megacorp = yes
+			# is_megacorp = yes
 			is_worker_coop_empire = yes
 		}
 	}
-	job_steward_add = 100
+	job_bureaucrat_add = 100
 	mult = value:pw_added|BASE_VALUE|$AMOUNT$|
 }
 
-triggered_desc = {
-	trigger = {
-		exists = owner
-		owner = {
-			always = $SHOW_JOB_STEWARD_EFFECT_DESC$
-			$OWNER_CONDITION$
-			is_megacorp = yes
-			is_worker_coop_empire = yes
-		}
-	}
-	text = job_steward_effect_desc
-}
+# triggered_desc = {
+# 	trigger = {
+# 		exists = owner
+# 		owner = {
+# 			always = $SHOW_JOB_STEWARD_EFFECT_DESC$
+# 			$OWNER_CONDITION$
+# 			is_megacorp = yes
+# 			is_worker_coop_empire = yes
+# 		}
+# 	}
+# 	text = job_steward_effect_desc
+# }

--- a/common/scripted_triggers/pw_scripted_triggers.txt
+++ b/common/scripted_triggers/pw_scripted_triggers.txt
@@ -821,7 +821,8 @@ pw_has_designation_mantle_crucible_check = {
 
 #Scope: Planet
 pw_jobs_any_research = {
-	num_pops_with_job_tag = {
+	# num_pops_with_job_tag = {
+	total_workforce_with_job_tag = {
 		value > 0
 		tags = { research }
 	}

--- a/common/static_modifiers/pw_art_exhibition_modifiers.txt
+++ b/common/static_modifiers/pw_art_exhibition_modifiers.txt
@@ -18,7 +18,8 @@ pw_art_mod_warrior_culture = {
 	pop_ethic_militarist_attraction_mult = 0.45
 	planet_amenities_mult = 0.10
 	planet_jobs_alloys_produces_mult = 0.05
-	job_duelist_add = 100
+	# job_duelist_add = 100
+	job_entertainer_add = 100
 }
 
 pw_art_mod_nationalistic_zeal = {

--- a/common/static_modifiers/pw_resource_modifiers.txt
+++ b/common/static_modifiers/pw_resource_modifiers.txt
@@ -21,80 +21,80 @@ pw_mod_demetrius_harvesting = {
 pw_mod_extra_mining_district = {
 	icon = "gfx/interface/icons/planet_modifiers/pw_mod_extra_mining_district.dds"
 	icon_frame = @pw_icon_frame_green
-	district_mining_max = 1
-	district_generator_max = -1
-	district_farming_max = -1
+	district_mining_max_add = 1
+	district_generator_max_add = -1
+	district_farming_max_add = -1
 	planet_districts_cost_mult = 0.15
 }
 
 pw_mod_extra_mining_district_extra = {
 	icon = "gfx/interface/icons/planet_modifiers/pw_mod_extra_mining_district.dds"
 	icon_frame = @pw_icon_frame_green
-	district_mining_max = 2
-	district_generator_max = -2
-	district_farming_max = -2
+	district_mining_max_add = 2
+	district_generator_max_add = -2
+	district_farming_max_add = -2
 	planet_districts_cost_mult = 0.25
 }
 
 pw_mod_extra_mining_district_max = {
 	icon = "gfx/interface/icons/planet_modifiers/pw_mod_extra_mining_district.dds"
 	icon_frame = @pw_icon_frame_green
-	district_mining_max = 4
-	district_generator_max = -4
-	district_farming_max = -4
+	district_mining_max_add = 4
+	district_generator_max_add = -4
+	district_farming_max_add = -4
 	planet_districts_cost_mult = 0.50
 }
 
 pw_mod_extra_generator_district = {
 	icon = "gfx/interface/icons/planet_modifiers/pw_mod_extra_generator_district.dds"
 	icon_frame = @pw_icon_frame_green
-	district_generator_max = 1
-	district_mining_max = -1
-	district_farming_max = -1
+	district_generator_max_add = 1
+	district_mining_max_add = -1
+	district_farming_max_add = -1
 	planet_districts_cost_mult = 0.15
 }
 
 pw_mod_extra_generator_district_extra = {
 	icon = "gfx/interface/icons/planet_modifiers/pw_mod_extra_generator_district.dds"
 	icon_frame = @pw_icon_frame_green
-	district_generator_max = 2
-	district_mining_max = -2
-	district_farming_max = -2
+	district_generator_max_add = 2
+	district_mining_max_add = -2
+	district_farming_max_add = -2
 	planet_districts_cost_mult = 0.25
 }
 
 pw_mod_extra_generator_district_max = {
 	icon = "gfx/interface/icons/planet_modifiers/pw_mod_extra_generator_district.dds"
 	icon_frame = @pw_icon_frame_green
-	district_generator_max = 4
-	district_mining_max = -4
-	district_farming_max = -4
+	district_generator_max_add = 4
+	district_mining_max_add = -4
+	district_farming_max_add = -4
 	planet_districts_cost_mult = 0.50
 }
 
 pw_mod_extra_farming_district = {
 	icon = "gfx/interface/icons/planet_modifiers/pw_mod_extra_farming_district.dds"
 	icon_frame = @pw_icon_frame_green
-	district_farming_max = 1
-	district_generator_max = -1
-	district_mining_max = -1
+	district_farming_max_add = 1
+	district_generator_max_add = -1
+	district_mining_max_add = -1
 	planet_districts_cost_mult = 0.15
 }
 
 pw_mod_extra_farming_district_extra = {
 	icon = "gfx/interface/icons/planet_modifiers/pw_mod_extra_farming_district.dds"
 	icon_frame = @pw_icon_frame_green
-	district_farming_max = 2
-	district_generator_max = -2
-	district_mining_max = -2
+	district_farming_max_add = 2
+	district_generator_max_add = -2
+	district_mining_max_add = -2
 	planet_districts_cost_mult = 0.25
 }
 
 pw_mod_extra_farming_district_max = {
 	icon = "gfx/interface/icons/planet_modifiers/pw_mod_extra_farming_district.dds"
 	icon_frame = @pw_icon_frame_green
-	district_farming_max = 4
-	district_generator_max = -4
-	district_mining_max = -4
+	district_farming_max_add = 4
+	district_generator_max_add = -4
+	district_mining_max_add = -4
 	planet_districts_cost_mult = 0.50
 }

--- a/common/static_modifiers/pw_static_modifiers.txt
+++ b/common/static_modifiers/pw_static_modifiers.txt
@@ -1313,7 +1313,7 @@ pw_holy_reliquary_archaeology_signet_ring = {
 pw_hidden_factory_archaeology_exhausted_minerals = {
 	icon = "gfx/interface/icons/planet_modifiers/pm_mineral_poor.dds"
 	icon_frame = @pw_icon_frame_red
-	district_mining_max = -2
+	district_mining_max_add = -2
 	planet_jobs_minerals_produces_mult = -0.15
 }
 

--- a/events/pw_wonder_events.txt
+++ b/events/pw_wonder_events.txt
@@ -444,8 +444,13 @@ planet_event = {
 					set_location = root
 					create_ship = {
 						name = random
-						design = "NAME_Colonizer"
+						# This desine have no components, so can't go to other systems.
+						# design = "NAME_Colonizer"
 						colonizer_species = root.owner.owner_species
+						# based on distar.71 event, "no_room" option.
+						random_existing_design = colonizer
+						prefix = no
+						upgradable = no
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
Disabled job_necromancer_add in Martial Avenue building.

## Changes
- Fixed Martial Avenue building in reanimater empires have untakable Necromancer job slots.
In Stellaris 4.0, job_necromancer_add adds dummy job slots. Soldier job slots from job_soldier_add will be swapped to takable Necromancer job slots.

## Impact
- No breaking changes expected.

## Notes
- This PR is independent of other pending or future PRs.