### PR TITLE
Fixed living spire building added entertainer job slots only 1 or 3.

### DIFF
--- a/common/buildings/pw_living_spire.txt
+++ b/common/buildings/pw_living_spire.txt
@@ -727,7 +727,7 @@ pw_building_living_spire_2 = {
 
 	inline_script = {
 		script = jobs/entertainers_add
-		AMOUNT = 1
+		AMOUNT = 100
 	}
 	ai_weight = {
 		weight = 65
@@ -1027,7 +1027,7 @@ pw_building_living_spire_3 = {
 
 	inline_script = {
 		script = jobs/entertainers_add
-		AMOUNT = 3
+		AMOUNT = 300
 	}
 	ai_weight = {
 		weight = 70


### PR DESCRIPTION
Fixed living spire building added entertainer job slots only 1 or 3.

Note: I will try to update for Stellaris 4.4. So this pull request is not hurried one.