### PR TITLE
- Updated for Stellaris 4.4.

### DIFF
--- a/common/armies/pw_armies.txt
+++ b/common/armies/pw_armies.txt
@@ -72,7 +72,7 @@ pw_army_war_titan = {
 			}
 			NOT = {
 				planet = {
-					has_planet_flag = pw_assembling_war_titan
+					has_carrier_flag = pw_assembling_war_titan
 				}
 			}
 		}
@@ -80,13 +80,13 @@ pw_army_war_titan = {
 
 	on_queued = {
 		planet = {
-			set_planet_flag = pw_assembling_war_titan
+			set_carrier_flag = pw_assembling_war_titan
 		}
 	}
 
 	on_unqueued = {
 		planet = {
-			remove_planet_flag = pw_assembling_war_titan
+			remove_carrier_flag = pw_assembling_war_titan
 		}
 	}
 }

--- a/common/ascension_perks/pw_ascension_perks.txt
+++ b/common/ascension_perks/pw_ascension_perks.txt
@@ -4,6 +4,7 @@ pw_ap_planetary_wonders = {
 		NOT = {
 			has_ascension_perk = pw_ap_planetary_wonders
 		}
+		is_nomadic = no
 	}
 
 	possible = {

--- a/common/buildings/pw_amenities_buildings.txt
+++ b/common/buildings/pw_amenities_buildings.txt
@@ -162,11 +162,11 @@ pw_building_transplanetary_logistics_network = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.1700 }
+		carrier_event = { id = pw_wonder.1700 }
 	}
 
 	# on_destroy = {
-	# 	planet_event = { id = pw_wonder.1703 }
+	# 	carrier_event = { id = pw_wonder.1703 }
 	# }
 
 	ai_weight = {
@@ -394,11 +394,11 @@ pw_building_transhabitat_logistics_network = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.1700 }
+		carrier_event = { id = pw_wonder.1700 }
 	}
 
 	# on_destroy = {
-	# 	planet_event = { id = pw_wonder.1703 }
+	# 	carrier_event = { id = pw_wonder.1703 }
 	# }
 
 	ai_weight = {
@@ -635,7 +635,7 @@ pw_building_festival_plaza = {
 	# }
 	
 	on_built = {
-		planet_event = { id = pw_wonder.1900 }
+		carrier_event = { id = pw_wonder.1900 }
 	}
 
 	ai_weight = {
@@ -909,7 +909,7 @@ pw_building_nostalgia_paradise = {
 	# }
 	
 	on_built = {
-		planet_event = { id = pw_wonder.2300 }
+		carrier_event = { id = pw_wonder.2300 }
 	}
 
 	ai_weight = {
@@ -1169,7 +1169,7 @@ pw_building_blossoming_preserve = {
 	# }
 	
 	on_built = {
-		planet_event = { id = pw_wonder.2500 }
+		carrier_event = { id = pw_wonder.2500 }
 	}
 
 	ai_weight = {

--- a/common/buildings/pw_army_buildings.txt
+++ b/common/buildings/pw_army_buildings.txt
@@ -184,11 +184,11 @@ pw_building_guardian_angel = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.1200 }
+		carrier_event = { id = pw_wonder.1200 }
 	}
 
 	# on_destroy = {
-	# 	planet_event = { id = pw_wonder.1205 }
+	# 	carrier_event = { id = pw_wonder.1205 }
 	# }
 
 	ai_weight = {
@@ -440,11 +440,11 @@ pw_building_stellar_sentinel = {
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
-		#planet_event = { id = pw_wonder.1250 }
+		#carrier_event = { id = pw_wonder.1250 }
 	}
 
 	# on_destroy = {
-	# 	planet_event = { id = pw_wonder.1205 }
+	# 	carrier_event = { id = pw_wonder.1205 }
 	# }
 
 	ai_weight = {
@@ -699,7 +699,7 @@ pw_building_martial_avenue = {
 	# }
 	
 	on_built = {
-		planet_event = { id = pw_wonder.2000 }
+		carrier_event = { id = pw_wonder.2000 }
 	}
 
 	ai_weight = {

--- a/common/buildings/pw_branch_office_buildings.txt
+++ b/common/buildings/pw_branch_office_buildings.txt
@@ -108,7 +108,7 @@ pw_building_bloodsports_arena = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_branch_office.110 }
+		carrier_event = { id = pw_branch_office.110 }
 	}
 
 	ai_weight = {
@@ -232,7 +232,7 @@ pw_building_meditation_garden = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_branch_office.120 }
+		carrier_event = { id = pw_branch_office.120 }
 	}
 
 	ai_weight = {
@@ -356,7 +356,7 @@ pw_building_innovation_hub = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_branch_office.130 }
+		carrier_event = { id = pw_branch_office.130 }
 	}
 
 	ai_weight = {
@@ -494,7 +494,7 @@ pw_building_salvation_shrine = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_branch_office.140 }
+		carrier_event = { id = pw_branch_office.140 }
 	}
 
 	ai_weight = {
@@ -618,7 +618,7 @@ pw_building_exotic_beauty_center = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_branch_office.150 }
+		carrier_event = { id = pw_branch_office.150 }
 	}
 
 	ai_weight = {
@@ -742,7 +742,7 @@ pw_building_national_pride_gallery = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_branch_office.160 }
+		carrier_event = { id = pw_branch_office.160 }
 	}
 
 	ai_weight = {
@@ -854,7 +854,7 @@ pw_building_aristocracy_tower = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_branch_office.170 }
+		carrier_event = { id = pw_branch_office.170 }
 	}
 
 	ai_weight = {
@@ -977,7 +977,7 @@ pw_building_factory_city = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_branch_office.180 }
+		carrier_event = { id = pw_branch_office.180 }
 	}
 
 	ai_weight = {
@@ -1078,7 +1078,7 @@ pw_building_tax_haven = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_branch_office.190 }
+		carrier_event = { id = pw_branch_office.190 }
 	}
 
 	ai_weight = {

--- a/common/buildings/pw_gestalt_buildings.txt
+++ b/common/buildings/pw_gestalt_buildings.txt
@@ -113,7 +113,7 @@ pw_building_conduit_of_unity_0 = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.2200 }
+		carrier_event = { id = pw_wonder.2200 }
 	}
 
 	ai_weight = {
@@ -685,7 +685,7 @@ pw_building_enigma_engine = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.1000 }
+		carrier_event = { id = pw_wonder.1000 }
 	}
 
 	ai_weight = {
@@ -1153,7 +1153,7 @@ pw_building_solipsist_debate_hall = {
 	# }
 
 	on_built = {
-		planet_event = { id = pw_wonder.1100 }
+		carrier_event = { id = pw_wonder.1100 }
 	}
 
 	ai_weight = {
@@ -1373,7 +1373,7 @@ pw_building_feasting_grounds = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.2700 }
+		carrier_event = { id = pw_wonder.2700 }
 	}
 
 	ai_weight = {

--- a/common/buildings/pw_government_buildings.txt
+++ b/common/buildings/pw_government_buildings.txt
@@ -212,7 +212,7 @@ pw_building_galactic_model = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.800 }
+		carrier_event = { id = pw_wonder.800 }
 	}
 
 	ai_weight = {
@@ -487,7 +487,7 @@ pw_building_aligned_galactic_model = {
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
-		#planet_event = { id = pw_wonder.850 }
+		#carrier_event = { id = pw_wonder.850 }
 	}
 
 	ai_weight = {
@@ -874,7 +874,7 @@ pw_building_panopticon = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.900 }
+		carrier_event = { id = pw_wonder.900 }
 	}
 
 	ai_weight = {
@@ -1104,11 +1104,11 @@ pw_building_forbidden_city = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.1800 }
+		carrier_event = { id = pw_wonder.1800 }
 	}
 
 	# on_destroy = {
-	# 	planet_event = { id = pw_wonder.1802 }
+	# 	carrier_event = { id = pw_wonder.1802 }
 	# }
 
 	ai_weight = {

--- a/common/buildings/pw_living_spire.txt
+++ b/common/buildings/pw_living_spire.txt
@@ -117,7 +117,7 @@ pw_building_living_spire_0 = {
 		text = pw_planet_wonder_lb
 	}
 	on_built = {
-		planet_event = {
+		carrier_event = {
 			id = pw_wonder.2100
 		}
 	}
@@ -727,7 +727,7 @@ pw_building_living_spire_2 = {
 
 	inline_script = {
 		script = jobs/entertainers_add
-		AMOUNT = 1
+		AMOUNT = 100
 	}
 	ai_weight = {
 		weight = 65
@@ -1027,7 +1027,7 @@ pw_building_living_spire_3 = {
 
 	inline_script = {
 		script = jobs/entertainers_add
-		AMOUNT = 3
+		AMOUNT = 300
 	}
 	ai_weight = {
 		weight = 70

--- a/common/buildings/pw_manufacturing_buildings.txt
+++ b/common/buildings/pw_manufacturing_buildings.txt
@@ -311,11 +311,11 @@ pw_building_mantle_crucible = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.1300 }
+		carrier_event = { id = pw_wonder.1300 }
 	}
 
 	# on_destroy = {
-	# 	planet_event = { id = pw_wonder.1310 }
+	# 	carrier_event = { id = pw_wonder.1310 }
 	# }
 
 	ai_weight = {
@@ -598,7 +598,7 @@ pw_building_titan_forge = {
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
-		#planet_event = { id = pw_wonder.1330 }
+		#carrier_event = { id = pw_wonder.1330 }
 	}
 
 	ai_weight = {
@@ -864,7 +864,7 @@ pw_building_industrial_hearth = {
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
-		#planet_event = { id = pw_wonder.1360 }
+		#carrier_event = { id = pw_wonder.1360 }
 	}
 
 	ai_weight = {

--- a/common/buildings/pw_research_buildings.txt
+++ b/common/buildings/pw_research_buildings.txt
@@ -203,7 +203,7 @@ pw_building_particle_supercollider = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.200 }
+		carrier_event = { id = pw_wonder.200 }
 	}
 
 	ai_weight = {
@@ -486,7 +486,7 @@ pw_building_interdimensional_collider = {
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
-		#planet_event = { id = pw_wonder.250 }
+		#carrier_event = { id = pw_wonder.250 }
 	}
 
 	ai_weight = {
@@ -779,7 +779,7 @@ pw_building_domed_city = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.300 }
+		carrier_event = { id = pw_wonder.300 }
 	}
 
 	ai_weight = {
@@ -1057,7 +1057,7 @@ pw_building_secluded_sector = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.300 }
+		carrier_event = { id = pw_wonder.300 }
 	}
 
 	ai_weight = {
@@ -1327,7 +1327,7 @@ pw_building_psionic_observatory = {
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
-		#planet_event = { id = pw_wonder.350 }
+		#carrier_event = { id = pw_wonder.350 }
 	}
 
 	ai_weight = {
@@ -1608,7 +1608,7 @@ pw_building_abyssal_crater_test_site = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.400 }
+		carrier_event = { id = pw_wonder.400 }
 	}
 
 	ai_weight = {
@@ -1875,7 +1875,7 @@ pw_building_abyssal_crater_test_site_habitat = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.400 }
+		carrier_event = { id = pw_wonder.400 }
 	}
 
 	ai_weight = {
@@ -2143,7 +2143,7 @@ pw_building_metal_vivarium = {
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
-		#planet_event = { id = pw_wonder.450 }
+		#carrier_event = { id = pw_wonder.450 }
 	}
 
 	ai_weight = {
@@ -2420,7 +2420,7 @@ pw_building_grand_archive = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.1600 }
+		carrier_event = { id = pw_wonder.1600 }
 	}
 
 	ai_weight = {

--- a/common/buildings/pw_resource_buildings.txt
+++ b/common/buildings/pw_resource_buildings.txt
@@ -22,7 +22,7 @@ pw_building_erebus_project = {
 			NOT = { merg_is_habitat = yes }
 			AND = {
 				owner = { is_void_dweller_empire = yes }
-				has_planet_flag = mining_habitat
+				has_carrier_flag = mining_habitat
 			}
 		}
 	}
@@ -227,7 +227,7 @@ pw_building_erebus_project = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.500 }
+		carrier_event = { id = pw_wonder.500 }
 	}
 
 	ai_weight = {
@@ -314,7 +314,7 @@ pw_building_erebus_fracking_plant = {
 			NOT = { merg_is_habitat = yes }
 			AND = {
 				owner = { is_void_dweller_empire = yes }
-				has_planet_flag = mining_habitat
+				has_carrier_flag = mining_habitat
 			}
 		}
 	}
@@ -547,7 +547,7 @@ pw_building_erebus_fracking_plant = {
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
-		#planet_event = { id = pw_wonder.550 }
+		#carrier_event = { id = pw_wonder.550 }
 	}
 
 	ai_weight = {
@@ -635,7 +635,7 @@ pw_building_helios_tower = {
 			AND = {
 				owner = { is_void_dweller_empire = yes }
 				OR = {
-					has_planet_flag = energy_habitat
+					has_carrier_flag = energy_habitat
 					owner = { is_gestalt = yes }
 				}
 			}
@@ -832,7 +832,7 @@ pw_building_helios_tower = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.600 }
+		carrier_event = { id = pw_wonder.600 }
 	}
 
 	ai_weight = {
@@ -919,7 +919,7 @@ pw_building_helios_translucent_obelisk = {
 			AND = {
 				owner = { is_void_dweller_empire = yes }
 				OR = {
-					has_planet_flag = energy_habitat
+					has_carrier_flag = energy_habitat
 					owner = { is_gestalt = yes }
 				}
 			}
@@ -1144,7 +1144,7 @@ pw_building_helios_translucent_obelisk = {
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
-		#planet_event = { id = pw_wonder.650 }
+		#carrier_event = { id = pw_wonder.650 }
 	}
 
 	ai_weight = {
@@ -1472,7 +1472,7 @@ pw_building_demetrius_fields = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.700 }
+		carrier_event = { id = pw_wonder.700 }
 	}
 
 	ai_weight = {
@@ -1829,7 +1829,7 @@ pw_building_demetrius_chemical_garden = {
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
-		#planet_event = { id = pw_wonder.750 }
+		#carrier_event = { id = pw_wonder.750 }
 	}
 
 	ai_weight = {

--- a/common/buildings/pw_trade_buildings.txt
+++ b/common/buildings/pw_trade_buildings.txt
@@ -357,7 +357,7 @@ pw_building_space_elevator = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.100 }
+		carrier_event = { id = pw_wonder.100 }
 	}
 
 	ai_weight = {
@@ -621,7 +621,7 @@ pw_building_department_of_xenoeconomics = {
 	# }
 	
 	on_built = {
-		planet_event = { id = pw_wonder.2600 }
+		carrier_event = { id = pw_wonder.2600 }
 	}
 
 	ai_weight = {

--- a/common/buildings/pw_unity_buildings.txt
+++ b/common/buildings/pw_unity_buildings.txt
@@ -186,7 +186,7 @@ pw_building_pavilion_of_wonders = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.1400 }
+		carrier_event = { id = pw_wonder.1400 }
 	}
 
 	ai_weight = {
@@ -259,7 +259,7 @@ pw_building_pavilion_of_wonders = {
 			exists = owner
 			owner = {
 				any_owned_planet = {
-					NOT = { is_planet = root }
+					NOT = { is_same_value = root }
 					OR = {
 						has_active_building = pw_building_pavilion_of_wonders
 						has_active_building = pw_building_fair_of_worlds
@@ -646,7 +646,7 @@ pw_building_fair_of_worlds = {
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
-		#planet_event = { id = pw_wonder.1430 }
+		#carrier_event = { id = pw_wonder.1430 }
 	}
 
 	ai_weight = {
@@ -704,7 +704,7 @@ pw_building_fair_of_worlds = {
 			exists = owner
 			owner = {
 				any_owned_planet = {
-					NOT = { is_planet = root }
+					NOT = { is_same_value = root }
 					OR = {
 						has_active_building = pw_building_pavilion_of_wonders
 						has_active_building = pw_building_fair_of_worlds
@@ -1149,7 +1149,7 @@ pw_building_museum_of_the_grotesque = {
 
 	on_built = {
 		#This is an upgrade, so on_building_upgraded triggers for this.
-		#planet_event = { id = pw_wonder.1460 }
+		#carrier_event = { id = pw_wonder.1460 }
 	}
 
 	ai_weight = {
@@ -1207,7 +1207,7 @@ pw_building_museum_of_the_grotesque = {
 			exists = owner
 			owner = {
 				any_owned_planet = {
-					NOT = { is_planet = root }
+					NOT = { is_same_value = root }
 					OR = {
 						has_active_building = pw_building_pavilion_of_wonders
 						has_active_building = pw_building_fair_of_worlds
@@ -1462,7 +1462,7 @@ pw_building_holy_reliquary = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.1500 }
+		carrier_event = { id = pw_wonder.1500 }
 	}
 
 	ai_weight = {
@@ -1755,7 +1755,7 @@ pw_building_unhallowed_necropolis = {
 	}
 
 	on_built = {
-		planet_event = { id = pw_wonder.2400 }
+		carrier_event = { id = pw_wonder.2400 }
 	}
 
 	ai_weight = {
@@ -1811,7 +1811,7 @@ pw_building_unhallowed_necropolis = {
 			exists = owner
 			owner = {
 				any_owned_planet = {
-					NOT = { is_planet = this }
+					NOT = { is_same_value = root }
 					OR = {
 						has_building = pw_building_unhallowed_necropolis
 						has_building_construction = pw_building_unhallowed_necropolis

--- a/common/decisions/pw_infrastructure_decisions.txt
+++ b/common/decisions/pw_infrastructure_decisions.txt
@@ -42,7 +42,7 @@ pw_decision_tls_infrastructure_distribution_1 = {
 	effect = {
 		add_deposit = pw_d_infrastructure_food_distribution
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1705 }
 		}
 	}
 
@@ -150,7 +150,7 @@ pw_decision_tls_infrastructure_distribution_2 = {
 		add_deposit = pw_d_infrastructure_energy_distribution
 		remove_deposit = pw_d_infrastructure_food_distribution
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1705 }
 		}
 	}
 
@@ -259,7 +259,7 @@ pw_decision_tls_infrastructure_distribution_3 = {
 		add_deposit = pw_d_infrastructure_goods_distribution
 		remove_deposit = pw_d_infrastructure_energy_distribution
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1705 }
 		}
 	}
 
@@ -373,8 +373,8 @@ pw_decision_tls_infrastructure_distribution_4 = {
 		add_deposit = pw_d_infrastructure_luxury_distribution
 		remove_deposit = pw_d_infrastructure_goods_distribution
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
-			planet_event = { #Final development
+			carrier_event = { id = pw_wonder.1705 }
+			carrier_event = { #Final development
 				id = pw_wonder.1715
 				days = 5
 			}
@@ -492,7 +492,7 @@ pw_decision_tls_infrastructure_emergency_1 = {
 	effect = {
 		add_deposit = pw_d_infrastructure_medical_posts
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1705 }
 		}
 	}
 
@@ -600,7 +600,7 @@ pw_decision_tls_infrastructure_emergency_2 = {
 		add_deposit = pw_d_infrastructure_habitation_support
 		remove_deposit = pw_d_infrastructure_medical_posts
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1705 }
 		}
 	}
 
@@ -709,7 +709,7 @@ pw_decision_tls_infrastructure_emergency_3 = {
 		add_deposit = pw_d_infrastructure_emergency_services
 		remove_deposit = pw_d_infrastructure_habitation_support
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1705 }
 		}
 	}
 
@@ -826,8 +826,8 @@ pw_decision_tls_infrastructure_emergency_4 = {
 		add_deposit = pw_d_infrastructure_crisis_responders
 		remove_deposit = pw_d_infrastructure_emergency_services
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
-			planet_event = { #Final development
+			carrier_event = { id = pw_wonder.1705 }
+			carrier_event = { #Final development
 				id = pw_wonder.1715
 				days = 5
 			}
@@ -945,7 +945,7 @@ pw_decision_tls_infrastructure_culture_1 = {
 	effect = {
 		add_deposit = pw_d_infrastructure_public_agoras
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1705 }
 		}
 	}
 
@@ -1053,7 +1053,7 @@ pw_decision_tls_infrastructure_culture_2 = {
 		add_deposit = pw_d_infrastructure_local_administration
 		remove_deposit = pw_d_infrastructure_public_agoras
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1705 }
 		}
 	}
 
@@ -1162,7 +1162,7 @@ pw_decision_tls_infrastructure_culture_3 = {
 		add_deposit = pw_d_infrastructure_distributed_education
 		remove_deposit = pw_d_infrastructure_local_administration
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1705 }
 		}
 	}
 
@@ -1280,9 +1280,9 @@ pw_decision_tls_infrastructure_culture_4 = {
 		add_deposit = pw_d_infrastructure_arts_installations
 		remove_deposit = pw_d_infrastructure_distributed_education
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
-			planet_event = { id = pw_wonder.1713 } #Ballroom Street Carnival
-			planet_event = { #Final development
+			carrier_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1713 } #Ballroom Street Carnival
+			carrier_event = { #Final development
 				id = pw_wonder.1715
 				days = 5
 			}
@@ -1400,7 +1400,7 @@ pw_decision_tls_infrastructure_industrial_1 = {
 	effect = {
 		add_deposit = pw_d_infrastructure_public_markets
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1705 }
 		}
 	}
 
@@ -1508,7 +1508,7 @@ pw_decision_tls_infrastructure_industrial_2 = {
 		add_deposit = pw_d_infrastructure_inventions_fair
 		remove_deposit = pw_d_infrastructure_public_markets
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1705 }
 		}
 	}
 
@@ -1617,7 +1617,7 @@ pw_decision_tls_infrastructure_industrial_3 = {
 		add_deposit = pw_d_infrastructure_cooperatives_manufacturers
 		remove_deposit = pw_d_infrastructure_inventions_fair
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
+			carrier_event = { id = pw_wonder.1705 }
 		}
 	}
 
@@ -1735,8 +1735,8 @@ pw_decision_tls_infrastructure_industrial_4 = {
 		add_deposit = pw_d_infrastructure_industrial_unions
 		remove_deposit = pw_d_infrastructure_cooperatives_manufacturers
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1705 }
-			planet_event = { #Final development
+			carrier_event = { id = pw_wonder.1705 }
+			carrier_event = { #Final development
 				id = pw_wonder.1715
 				days = 5
 			}
@@ -1856,7 +1856,7 @@ pw_decision_fc_infrastructure_capital_1 = {
 	effect = {
 		add_deposit = pw_d_infrastructure_planetary_command
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -1966,7 +1966,7 @@ pw_decision_fc_infrastructure_capital_2 = {
 		add_deposit = pw_d_infrastructure_governor_mansion
 		remove_deposit = pw_d_infrastructure_planetary_command
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -2078,9 +2078,9 @@ pw_decision_fc_infrastructure_capital_seat_of_power = {
 		add_deposit = pw_d_infrastructure_seat_of_power
 		remove_deposit = pw_d_infrastructure_governor_mansion
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
-			planet_event = { id = pw_wonder.1803 } #Destroy the previous Seat of Power
-			planet_event = { #Final development
+			carrier_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1803 } #Destroy the previous Seat of Power
+			carrier_event = { #Final development
 				id = pw_wonder.1815
 				days = 5
 			}
@@ -2199,9 +2199,9 @@ pw_decision_fc_infrastructure_capital_throne_room = {
 		add_deposit = pw_d_infrastructure_throne_room
 		remove_deposit = pw_d_infrastructure_governor_mansion
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
-			planet_event = { id = pw_wonder.1803 } #Destroy the previous Imperial Throne
-			planet_event = { #Final development
+			carrier_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1803 } #Destroy the previous Imperial Throne
+			carrier_event = { #Final development
 				id = pw_wonder.1815
 				days = 5
 			}
@@ -2317,8 +2317,8 @@ pw_decision_fc_infrastructure_capital_holy_throne = {
 		add_deposit = pw_d_infrastructure_imperial_holy_throne
 		remove_deposit = pw_d_infrastructure_throne_room
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
-			planet_event = { id = pw_wonder.1803 } #Destroy the previous Imperial Throne
+			carrier_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1803 } #Destroy the previous Imperial Throne
 		}
 	}
 
@@ -2441,8 +2441,8 @@ pw_decision_fc_infrastructure_capital_galactic_throne = {
 			remove_deposit = pw_d_infrastructure_imperial_holy_throne
 		}
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
-			planet_event = { id = pw_wonder.1803 } #Destroy the previous Imperial Throne
+			carrier_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1803 } #Destroy the previous Imperial Throne
 		}
 	}
 
@@ -2512,7 +2512,7 @@ pw_decision_fc_infrastructure_capital_resort = {
 	effect = {
 		add_deposit = pw_d_infrastructure_luxury_retreat
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -2609,7 +2609,7 @@ pw_decision_fc_infrastructure_capital_penal = {
 	effect = {
 		add_deposit = pw_d_infrastructure_wardens_directorate
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -2706,7 +2706,7 @@ pw_decision_fc_infrastructure_capital_slave = {
 	effect = {
 		add_deposit = pw_d_infrastructure_overseers_ring
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -2809,7 +2809,7 @@ pw_decision_fc_infrastructure_emergency_1 = {
 	effect = {
 		add_deposit = pw_d_infrastructure_palatial_physicians
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -2916,7 +2916,7 @@ pw_decision_fc_infrastructure_emergency_2 = {
 		add_deposit = pw_d_infrastructure_city_defenders
 		remove_deposit = pw_d_infrastructure_palatial_physicians
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -3024,7 +3024,7 @@ pw_decision_fc_infrastructure_emergency_3 = {
 		add_deposit = pw_d_infrastructure_crisis_bunker
 		remove_deposit = pw_d_infrastructure_city_defenders
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -3140,8 +3140,8 @@ pw_decision_fc_infrastructure_emergency_4 = {
 		add_deposit = pw_d_infrastructure_personal_guardian
 		remove_deposit = pw_d_infrastructure_crisis_bunker
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
-			planet_event = { #Final development
+			carrier_event = { id = pw_wonder.1805 }
+			carrier_event = { #Final development
 				id = pw_wonder.1815
 				days = 5
 			}
@@ -3259,7 +3259,7 @@ pw_decision_fc_infrastructure_power_1 = {
 	effect = {
 		add_deposit = pw_d_infrastructure_central_of_disinformation
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -3366,7 +3366,7 @@ pw_decision_fc_infrastructure_power_2 = {
 		add_deposit = pw_d_infrastructure_center_of_justice
 		remove_deposit = pw_d_infrastructure_central_of_disinformation
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -3474,7 +3474,7 @@ pw_decision_fc_infrastructure_power_3 = {
 		add_deposit = pw_d_infrastructure_central_treasury
 		remove_deposit = pw_d_infrastructure_center_of_justice
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -3594,8 +3594,8 @@ pw_decision_fc_infrastructure_power_4 = {
 		add_deposit = pw_d_infrastructure_galactic_bureau
 		remove_deposit = pw_d_infrastructure_central_treasury
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
-			planet_event = { #Final development
+			carrier_event = { id = pw_wonder.1805 }
+			carrier_event = { #Final development
 				id = pw_wonder.1815
 				days = 5
 			}
@@ -3712,7 +3712,7 @@ pw_decision_fc_infrastructure_ambassador_chambers = {
 	effect = {
 		add_deposit = pw_d_infrastructure_ambassador_chambers
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -3811,7 +3811,7 @@ pw_decision_fc_infrastructure_internal_affairs = {
 	effect = {
 		add_deposit = pw_d_infrastructure_internal_affairs
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -3911,7 +3911,7 @@ pw_decision_fc_infrastructure_intellectual_circles = {
 	effect = {
 		add_deposit = pw_d_infrastructure_intellectual_circles
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -4003,7 +4003,7 @@ pw_decision_fc_infrastructure_holy_tribunal = {
 	effect = {
 		add_deposit = pw_d_infrastructure_holy_tribunal
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -4106,7 +4106,7 @@ pw_decision_fc_infrastructure_ballroom = {
 	effect = {
 		add_deposit = pw_d_infrastructure_ballroom
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -4201,7 +4201,7 @@ pw_decision_fc_infrastructure_war_room = {
 	effect = {
 		add_deposit = pw_d_infrastructure_war_room
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1805 }
+			carrier_event = { id = pw_wonder.1805 }
 		}
 	}
 
@@ -4323,7 +4323,7 @@ pw_decision_cu_cyber_pylon = {
 	effect = {
 		add_deposit = pw_d_integration_cyber_pylon
 		hidden_effect = {
-			planet_event = { id = pw_wonder.2205 }
+			carrier_event = { id = pw_wonder.2205 }
 		}
 	}
 
@@ -4427,7 +4427,7 @@ pw_decision_cu_CARE_facility = {
 	effect = {
 		add_deposit = pw_d_integration_CARE_facility
 		hidden_effect = {
-			planet_event = { id = pw_wonder.2205 }
+			carrier_event = { id = pw_wonder.2205 }
 		}
 	}
 
@@ -4531,7 +4531,7 @@ pw_decision_cu_coordination_center = {
 	effect = {
 		add_deposit = pw_d_integration_coordination_center
 		hidden_effect = {
-			planet_event = { id = pw_wonder.2205 }
+			carrier_event = { id = pw_wonder.2205 }
 		}
 	}
 
@@ -4636,7 +4636,7 @@ pw_decision_cu_xeno_accommodation = {
 	effect = {
 		add_deposit = pw_d_integration_xeno_accommodation
 		hidden_effect = {
-			planet_event = { id = pw_wonder.2205 }
+			carrier_event = { id = pw_wonder.2205 }
 		}
 	}
 
@@ -4741,7 +4741,7 @@ pw_decision_cu_drone_surveillance = {
 	effect = {
 		add_deposit = pw_d_integration_drone_surveillance
 		hidden_effect = {
-			planet_event = { id = pw_wonder.2205 }
+			carrier_event = { id = pw_wonder.2205 }
 		}
 	}
 
@@ -4849,7 +4849,7 @@ pw_decision_cu_integrated_replication = {
 	effect = {
 		add_deposit = pw_d_integration_integrated_replication
 		hidden_effect = {
-			planet_event = { id = pw_wonder.2205 }
+			carrier_event = { id = pw_wonder.2205 }
 		}
 	}
 
@@ -4936,7 +4936,7 @@ pw_decision_cu_shard_of_enigma = {
 	effect = {
 		add_deposit = pw_d_integration_shard_of_enigma
 		hidden_effect = {
-			planet_event = { id = pw_wonder.2205 }
+			carrier_event = { id = pw_wonder.2205 }
 		}
 	}
 
@@ -5036,7 +5036,7 @@ pw_decision_cu_chamber_of_reflection = {
 	effect = {
 		add_deposit = pw_d_integration_chamber_of_reflection
 		hidden_effect = {
-			planet_event = { id = pw_wonder.2205 }
+			carrier_event = { id = pw_wonder.2205 }
 		}
 	}
 
@@ -5128,7 +5128,7 @@ pw_decision_cu_stargazing_orrery = {
 	effect = {
 		add_deposit = pw_d_integration_stargazing_orrery
 		hidden_effect = {
-			planet_event = { id = pw_wonder.2205 }
+			carrier_event = { id = pw_wonder.2205 }
 		}
 	}
 

--- a/common/decisions/pw_wonder_decisions.txt
+++ b/common/decisions/pw_wonder_decisions.txt
@@ -102,7 +102,7 @@ pw_decision_erebus_prospecting = {
 			days = @pw_decision_resource_duration
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.503
 			}
 		}
@@ -152,7 +152,7 @@ pw_decision_helios_seeding = {
 			days = @pw_decision_resource_duration
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.603
 			}
 		}
@@ -202,7 +202,7 @@ pw_decision_demetrius_harvesting = {
 			days = @pw_decision_resource_duration
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.703
 			}
 		}
@@ -260,7 +260,7 @@ pw_decision_manage_land_repurposing = {
 	effect = {
 		if = {
 			limit = { owner = { is_ai = no }}
-			planet_event = { id = pw_wonder.790 }
+			carrier_event = { id = pw_wonder.790 }
 		}
 		else = {
 			if = {
@@ -347,7 +347,7 @@ pw_decision_SE_install_space_ramp = {
 	effect = {
 		add_deposit = pw_d_SE_space_ramp
 		hidden_effect = {
-			planet_event = { id = pw_wonder.120 }
+			carrier_event = { id = pw_wonder.120 }
 		}
 	}
 
@@ -433,7 +433,7 @@ pw_decision_SE_install_nuclear_launcher = {
 		}
 		add_deposit = pw_d_SE_nuclear_launcher
 		hidden_effect = {
-			planet_event = { id = pw_wonder.120 }
+			carrier_event = { id = pw_wonder.120 }
 		}
 	}
 
@@ -476,7 +476,7 @@ pw_decision_SE_install_skyhook = {
 	effect = {
 		add_deposit = pw_d_SE_skyhook
 		hidden_effect = {
-			planet_event = { id = pw_wonder.120 }
+			carrier_event = { id = pw_wonder.120 }
 		}
 	}
 
@@ -735,7 +735,7 @@ pw_decision_SE_counterweight_habitat = {
 		NOT = { has_modifier = pw_mod_space_elevator_moon_colony_expansion_1 }
 		NOT = { has_modifier = pw_mod_space_elevator_moon_colony_expansion_2 }
 		NOT = { has_modifier = pw_mod_space_elevator_moon_colony_expansion_3 }
-		NOT = { has_planet_flag = has_megastructure }
+		NOT = { has_carrier_flag = has_megastructure }
 		# NOT = { has_moon = yes }
 	}
 
@@ -821,7 +821,7 @@ pw_decision_SE_open_for_galactic_market = {
 		owner = {
 			is_galactic_community_member = yes
 		}
-		NOT = { has_planet_flag = pw_SE_is_choosing_market_bonus }
+		NOT = { has_carrier_flag = pw_SE_is_choosing_market_bonus }
 		NOT = { has_modifier = pw_mod_space_elevator_open_market_free_assets_concession }
 		NOT = { has_modifier = pw_mod_space_elevator_open_market_free_assets_concession_gestalt }
 		NOT = { has_modifier = pw_mod_space_elevator_open_market_industrial_protectionism }
@@ -862,7 +862,7 @@ pw_decision_SE_open_for_galactic_market = {
 			}
 			owner = { add_modifier = { modifier = pw_mod_space_elevator_open_market_gestalt }}
 		}
-		planet_event = {
+		carrier_event = {
 			id = pw_wonder.130
 		}
 	}
@@ -911,7 +911,7 @@ pw_decision_SE_change_galactic_market_bonus = {
 		owner = {
 			is_galactic_community_member = yes
 		}
-		NOT = { has_planet_flag = pw_SE_is_choosing_market_bonus }
+		NOT = { has_carrier_flag = pw_SE_is_choosing_market_bonus }
 		OR = {
 			has_modifier = pw_mod_space_elevator_open_market_free_assets_concession
 			has_modifier = pw_mod_space_elevator_open_market_free_assets_concession_gestalt
@@ -954,7 +954,7 @@ pw_decision_SE_change_galactic_market_bonus = {
 			}
 			owner = { add_modifier = { modifier = pw_mod_space_elevator_open_market_gestalt }}
 		}
-		planet_event = {
+		carrier_event = {
 			id = pw_wonder.130
 		}
 	}
@@ -1008,7 +1008,7 @@ pw_decision_rebuild_flying_fortress = {
 			type = pw_army_flying_fortress
 		}
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1206 }
+			carrier_event = { id = pw_wonder.1206 }
 		}
 	}
 
@@ -1034,7 +1034,7 @@ pw_decision_guardian_angel_change_peace_choice = {
 	}
 
 	potential = {
-		has_planet_flag = pw_guardian_angel_choice
+		has_carrier_flag = pw_guardian_angel_choice
 	}
 
 	allow = {
@@ -1046,7 +1046,7 @@ pw_decision_guardian_angel_change_peace_choice = {
 
 	effect = {
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1207
 			}
 		}
@@ -1220,7 +1220,7 @@ pw_decision_pavilion_of_wonders_planetary_art_exhibition = {
 		owner = {
 			NOT = {
 				any_owned_planet = {
-					NOT = { is_planet = root }
+					NOT = { is_same_value = root }
 					has_active_building = pw_building_pavilion_of_wonders
 				}
 			}
@@ -1241,7 +1241,7 @@ pw_decision_pavilion_of_wonders_planetary_art_exhibition = {
 	effect = {
 		custom_tooltip = pw_decision_pavilion_of_wonders_planetary_art_exhibition_tooltip
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_art_exhibition.1
 			}
 		}
@@ -1276,7 +1276,7 @@ pw_decision_pavilion_of_wonders_interplanetary_art_exhibition = {
 		has_active_building = pw_building_pavilion_of_wonders
 		owner = {
 			any_owned_planet = {
-				NOT = { is_planet = root }
+				NOT = { is_same_value = root }
 				has_active_building = pw_building_pavilion_of_wonders
 			}
 		}
@@ -1441,7 +1441,7 @@ pw_decision_fair_of_worlds_planetary_art_exhibition = {
 		owner = {
 			NOT = {
 				any_owned_planet = {
-					NOT = { is_planet = root }
+					NOT = { is_same_value = root }
 					has_active_building = pw_building_pavilion_of_wonders
 
 				}
@@ -1463,7 +1463,7 @@ pw_decision_fair_of_worlds_planetary_art_exhibition = {
 	effect = {
 		custom_tooltip = pw_decision_fair_of_worlds_planetary_art_exhibition_tooltip
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_art_exhibition.4
 			}
 		}
@@ -1500,7 +1500,7 @@ pw_decision_fair_of_worlds_interplanetary_art_exhibition = {
 				has_active_building = pw_building_pavilion_of_wonders
 				owner = {
 					any_owned_planet = {
-						NOT = { is_planet = root }
+						NOT = { is_same_value = root }
 						has_active_building = pw_building_fair_of_worlds
 					}
 				}
@@ -1509,7 +1509,7 @@ pw_decision_fair_of_worlds_interplanetary_art_exhibition = {
 				has_active_building = pw_building_fair_of_worlds
 				owner = {
 					any_owned_planet = {
-						NOT = { is_planet = root }
+						NOT = { is_same_value = root }
 						has_active_building = pw_building_pavilion_of_wonders
 					}
 				}
@@ -1652,7 +1652,7 @@ pw_decision_museum_of_the_grotesque_planetary_art_exhibition = {
 		owner = {
 			NOT = {
 				any_owned_planet = {
-					NOT = { is_planet = root }
+					NOT = { is_same_value = root }
 					has_active_building = pw_building_pavilion_of_wonders
 				}
 			}
@@ -1673,7 +1673,7 @@ pw_decision_museum_of_the_grotesque_planetary_art_exhibition = {
 	effect = {
 		custom_tooltip = pw_decision_museum_of_the_grotesque_planetary_art_exhibition_tooltip
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_art_exhibition.7
 			}
 		}
@@ -1710,7 +1710,7 @@ pw_decision_museum_of_the_grotesque_interplanetary_art_exhibition = {
 				has_active_building = pw_building_pavilion_of_wonders
 				owner = {
 					any_owned_planet = {
-						NOT = { is_planet = root }
+						NOT = { is_same_value = root }
 						has_active_building = pw_building_museum_of_the_grotesque
 					}
 				}
@@ -1719,7 +1719,7 @@ pw_decision_museum_of_the_grotesque_interplanetary_art_exhibition = {
 				has_active_building = pw_building_museum_of_the_grotesque
 				owner = {
 					any_owned_planet = {
-						NOT = { is_planet = root }
+						NOT = { is_same_value = root }
 						has_active_building = pw_building_pavilion_of_wonders
 					}
 				}
@@ -1909,7 +1909,7 @@ pw_decision_host_peace_festival = {
 
 	potential = {
 		has_active_building = pw_building_festival_plaza
-		NOT = { has_planet_flag = pw_festival_plaza_choice }
+		NOT = { has_carrier_flag = pw_festival_plaza_choice }
 	}
 
 	allow = {
@@ -1920,7 +1920,7 @@ pw_decision_host_peace_festival = {
 	}
 
 	effect = {
-		planet_event = { id = pw_wonder.1902 }
+		carrier_event = { id = pw_wonder.1902 }
 	}
 
 	ai_weight = {
@@ -2312,7 +2312,7 @@ pw_decision_host_military_parade = {
 
 	potential = {
 		has_active_building = pw_building_martial_avenue
-		NOT = { has_planet_flag = pw_martial_avenue_choice }
+		NOT = { has_carrier_flag = pw_martial_avenue_choice }
 	}
 
 	allow = {
@@ -2323,7 +2323,7 @@ pw_decision_host_military_parade = {
 	}
 
 	effect = {
-		planet_event = { id = pw_wonder.2003 }
+		carrier_event = { id = pw_wonder.2003 }
 	}
 
 	ai_weight = {
@@ -3041,7 +3041,7 @@ pw_decision_living_spire_change_designation = {
 
 	effect = {
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.2120
 			}
 		}
@@ -3082,7 +3082,7 @@ pw_decision_nostalgia_paradise_change_theme = {
 	}
 
 	effect = {
-		planet_event = {
+		carrier_event = {
 			id = pw_wonder.2310
 		}
 	}
@@ -3302,7 +3302,7 @@ pw_decision_FG_organize_feast = {
 	}
 
 	effect = {
-		planet_event = {
+		carrier_event = {
 			id = pw_wonder.2710
 		}
 	}

--- a/common/deposits/pw_planetary_deposits.txt
+++ b/common/deposits/pw_planetary_deposits.txt
@@ -693,7 +693,7 @@ pw_d_parliament_of_the_void_speakers = {
 
 	planet_modifier = {
 		pop_cat_worker_happiness = 0.05
-		pop_cat_slave_happiness = 0.05
+		pop_slave_happiness = 0.05
 	}
 
 	resources = {

--- a/common/event_chains/pw_event_chains.txt
+++ b/common/event_chains/pw_event_chains.txt
@@ -16,6 +16,7 @@ pw_multiple_asteroid_attack = {
 			max = 5
 		}
 	}
+	situation_log_category = urgent_matters
 }
 
 # Grand Archive event chains:
@@ -28,6 +29,7 @@ pw_assemble_ARK_project_chain = {
 			max = 3
 		}
 	}
+	situation_log_category = developments
 }
 
 pw_assemble_cradle_initiative_chain = {
@@ -38,6 +40,7 @@ pw_assemble_cradle_initiative_chain = {
 			max = 4
 		}
 	}
+	situation_log_category = developments
 }
 
 pw_assemble_stellarium_chain = {
@@ -48,6 +51,7 @@ pw_assemble_stellarium_chain = {
 			max = 5
 		}
 	}
+	situation_log_category = developments
 }
 
 pw_assemble_meta_architectural_complex_chain = {
@@ -58,20 +62,24 @@ pw_assemble_meta_architectural_complex_chain = {
 			max = 3
 		}
 	}
+	situation_log_category = developments
 }
 
 # Research Wonders Event Chains:
 pw_particle_supercollider_experiment_chain = {
 	icon = "gfx/interface/icons/situation_log/situation_log_physics.dds"
 	picture = GFX_evt_surreal_visions
+	situation_log_category = developments
 }
 
 pw_domed_city_experiment_chain = {
 	icon = "gfx/interface/icons/situation_log/situation_log_society.dds"
 	picture = GFX_evt_pw_domed_city
+	situation_log_category = developments
 }
 
 pw_abyssal_crater_test_Site_experiment_chain = {
 	icon = "gfx/interface/icons/situation_log/situation_log_engineering.dds"
 	picture = GFX_evt_pw_abyssal_crater_test_site
+	situation_log_category = developments
 }

--- a/common/pop_jobs/pw_gestalt_jobs.txt
+++ b/common/pop_jobs/pw_gestalt_jobs.txt
@@ -48,7 +48,6 @@ pw_mining_coordinator = {
 
 	weight = {
 		weight = @synapse_drone_job_weight
-		mult = value:job_weights_modifier|JOB|pw_mining_coordinator|RESOURCE|minerals|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|planet_jobs_minerals_produces_mult|
 		modifier = {
 			factor = 0.9
@@ -116,7 +115,6 @@ pw_energy_coordinator = {
 
 	weight = {
 		weight = @synapse_drone_job_weight
-		mult = value:job_weights_modifier|JOB|pw_energy_coordinator|RESOURCE|energy|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|planet_jobs_energy_produces_mult|
 		modifier = {
 			factor = 0.9
@@ -188,7 +186,6 @@ pw_food_coordinator = {
 
 	weight = {
 		weight = @synapse_drone_job_weight
-		mult = value:job_weights_modifier|JOB|pw_food_coordinator|RESOURCE|food|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|planet_jobs_food_produces_mult|
 		modifier = {
 			factor = 0.9
@@ -257,7 +254,6 @@ pw_enigma_decipher = {
 
 	weight = {
 		weight = 50
-		mult = value:job_weights_research_modifier|JOB|pw_enigma_decipher|
 		modifier = {
 			factor = 5
 			planet = { planet_crime > 22 }
@@ -312,7 +308,6 @@ pw_domed_city_subject_drone = {
 
 	weight = {
 		weight = @simple_drone_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_domed_city_subject_drone|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|planet_jobs_society_research_produces_mult|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
 		modifier = {
@@ -368,7 +363,6 @@ pw_poly_artisan_drone = {
 
 	weight = {
 		weight = 50
-		mult = value:job_weights_modifier|JOB|pw_poly_artisan_drone|RESOURCE|consumer_goods|
 		modifier = {
 			factor = 0
 			exists = owner
@@ -431,7 +425,6 @@ pw_lunar_archivist_gestalt = {
 
 	weight = {
 		weight = @complex_drone_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_lunar_archivist_gestalt|
 		modifier = {
 			factor = 1.25
 			always = yes
@@ -553,7 +546,6 @@ pw_logistics_drone = {
 
 	weight = {
 		weight = @synapse_drone_job_weight
-		mult = value:job_weights_modifier|JOB|pw_logistics_drone|RESOURCE|unity|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|planet_jobs_produces_mult|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
 		modifier = {
@@ -614,7 +606,6 @@ pw_tomb_surveyor = {
 
 	weight = {
 		weight = @complex_drone_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_tomb_surveyor|
 		modifier = {
 			factor = 0.9
 			exists = owner
@@ -703,7 +694,6 @@ pw_preserver_drone = {
 
 	weight = {
 		weight = @complex_drone_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_preserver_drone|
 		modifier = {
 			factor = 0.9
 			exists = owner
@@ -787,7 +777,6 @@ pw_banquet_steward_drone = {
 
 	weight = {
 		weight = @complex_drone_job_weight
-		mult = value:job_weights_modifier|JOB|pw_banquet_steward_drone|RESOURCE|unity|
 		modifier = {
 			weight = 100
 			exists = owner

--- a/common/pop_jobs/pw_regular_jobs.txt
+++ b/common/pop_jobs/pw_regular_jobs.txt
@@ -50,7 +50,6 @@ pw_mining_director = {
 
 	weight = {
 		weight = @ruler_job_weight
-		mult = value:job_weights_modifier|JOB|pw_mining_director|RESOURCE|minerals|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|planet_jobs_minerals_produces_mult|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
 		modifier = {
@@ -133,7 +132,6 @@ pw_energy_director = {
 
 	weight = {
 		weight = @ruler_job_weight
-		mult = value:job_weights_modifier|JOB|pw_energy_director|RESOURCE|energy|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|planet_jobs_energy_produces_mult|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
 		modifier = {
@@ -254,7 +252,6 @@ pw_agriculture_director = {
 
 	weight = {
 		weight = @ruler_job_weight
-		mult = value:job_weights_modifier|JOB|pw_agriculture_director|RESOURCE|food|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|planet_jobs_food_produces_mult|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
 		modifier = {
@@ -332,7 +329,6 @@ pw_domed_city_test_subject = {
 
 	weight = {
 		weight = @specialist_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_domed_city_subject_drone|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|planet_jobs_society_research_produces_mult|
 		modifier = {
 			factor = 0.2
@@ -429,7 +425,6 @@ pw_big_brother = {
 
 	weight = {
 		weight = @ruler_job_weight
-		mult = value:job_weights_modifier|JOB|pw_big_brother|RESOURCE|unity|
 		modifier = {
 			factor = 0.2
 			has_citizenship_rights = no
@@ -514,7 +509,6 @@ pw_tourist = {
 
 	weight = {
 		weight = @clerk_job_weight
-		mult = value:job_weights_modifier|JOB|pw_tourist|RESOURCE|trade|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
 		modifier = {
 			factor = 0.25
@@ -592,7 +586,6 @@ pw_poly_artisan = {
 
 	weight = {
 		weight = @specialist_job_weight
-		mult = value:job_weights_modifier|JOB|pw_poly_artisan|RESOURCE|consumer_goods|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
 		modifier = {
 			factor = 0.2
@@ -658,8 +651,6 @@ pw_diversity_curator = {
 
 	weight = {
 		weight = @high_prio_specialist_job_weight
-		mult = value:job_weights_modifier|JOB|pw_diversity_curator|RESOURCE|unity|
-		mult = value:job_weights_research_modifier|JOB|pw_diversity_curator|
 		modifier = {
 			factor = 0.1
 			has_citizenship_rights = no
@@ -727,8 +718,6 @@ pw_degeneracy_curator = {
 
 	weight = {
 		weight = @high_prio_specialist_job_weight
-		mult = value:job_weights_modifier|JOB|pw_degeneracy_curator|RESOURCE|unity|
-		mult = value:job_weights_research_modifier|JOB|pw_degeneracy_curator|
 		modifier = {
 			factor = 0.1
 			has_citizenship_rights = no
@@ -789,7 +778,6 @@ pw_grand_archivist = {
 
 	weight = {
 		weight = @specialist_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_grand_archivist|
 		modifier = {
 			factor = 1.25
 			always = yes
@@ -871,7 +859,6 @@ pw_master_archivist = {
 
 	weight = {
 		weight = @ruler_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_master_archivist|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
 		modifier = {
 			factor = 0.2
@@ -944,7 +931,6 @@ pw_lunar_archivist = {
 
 	weight = {
 		weight = @specialist_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_lunar_archivist|
 		modifier = {
 			factor = 1.25
 			always = yes
@@ -1030,8 +1016,6 @@ pw_relic_keeper = {
 	}
 	weight = {
 		weight = @ruler_job_weight
-		mult = value:job_weights_modifier|JOB|pw_relic_keeper|RESOURCE|unity|
-		mult = value:job_weights_research_modifier|JOB|pw_relic_keeper|
 		mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
 		modifier = {
 			factor = 0.2
@@ -1105,7 +1089,6 @@ pw_tomb_scholar = {
 
 	weight = {
 		weight = @specialist_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_tomb_scholar|
 		modifier = {
 			factor = 0.2
 			has_citizenship_rights = no
@@ -1172,7 +1155,6 @@ pw_preserver = {
 
 	weight = {
 		weight = @specialist_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_preserver|
 		modifier = {
 			factor = 0.2
 			has_citizenship_rights = no

--- a/common/pop_jobs/pw_researcher_jobs.txt
+++ b/common/pop_jobs/pw_researcher_jobs.txt
@@ -36,7 +36,6 @@ pw_researcher_particle_supercollider = {
 
 	weight = {
 		weight = @specialist_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_researcher_particle_supercollider|
 		modifier = {
 			factor = 0.2
 			has_citizenship_rights = no
@@ -62,16 +61,6 @@ pw_researcher_particle_supercollider = {
 	}
 
 	inline_script = "jobs/automodding_priority_research"
-
-	promotion = {
-		time = @standard_promotion_time
-		effect = {
-			pop_amount_change_category = {
-				CATEGORY = specialist
-				AMOUNT = local_pop_amount
-			}
-		}
-	}
 }
 
 pw_researcher_domed_city = {
@@ -111,7 +100,6 @@ pw_researcher_domed_city = {
 
 	weight = {
 		weight = @specialist_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_researcher_domed_city|
 		modifier = {
 			factor = 0.2
 			has_citizenship_rights = no
@@ -137,16 +125,6 @@ pw_researcher_domed_city = {
 	}
 
 	inline_script = "jobs/automodding_priority_research"
-
-	promotion = {
-		time = @standard_promotion_time
-		effect = {
-			pop_amount_change_category = {
-				CATEGORY = specialist
-				AMOUNT = local_pop_amount
-			}
-		}
-	}
 }
 
 pw_researcher_abyssal_crater_test_site = {
@@ -187,7 +165,6 @@ pw_researcher_abyssal_crater_test_site = {
 
 	weight = {
 		weight = @specialist_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_researcher_abyssal_crater_test_site|
 		modifier = {
 			factor = 0.2
 			has_citizenship_rights = no
@@ -213,14 +190,4 @@ pw_researcher_abyssal_crater_test_site = {
 	}
 
 	inline_script = "jobs/automodding_priority_research"
-
-	promotion = {
-		time = @standard_promotion_time
-		effect = {
-			pop_amount_change_category = {
-				CATEGORY = specialist
-				AMOUNT = local_pop_amount
-			}
-		}
-	}
 }

--- a/common/pop_jobs/pw_researcher_jobs_gestalt.txt
+++ b/common/pop_jobs/pw_researcher_jobs_gestalt.txt
@@ -120,7 +120,6 @@ pw_calculator_particle_supercollider = {
 
 	weight = {
 		weight = @complex_drone_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_calculator_particle_supercollider|
 		modifier = {
 			factor = 0.9
 			exists = owner
@@ -132,15 +131,6 @@ pw_calculator_particle_supercollider = {
 
 	inline_script = "jobs/automodding_priority_research"
 
-	promotion = {
-		time = @standard_promotion_time
-		effect = {
-			pop_amount_change_category = {
-				CATEGORY = complex_drone
-				AMOUNT = local_pop_amount
-			}
-		}
-	}
 }
 
 pw_calculator_domed_city = {
@@ -214,7 +204,6 @@ pw_calculator_domed_city = {
 
 	weight = {
 		weight = @complex_drone_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_calculator_domed_city|
 		modifier = {
 			factor = 0.9
 			exists = owner
@@ -225,16 +214,6 @@ pw_calculator_domed_city = {
 	}
 
 	inline_script = "jobs/automodding_priority_research"
-
-	promotion = {
-		time = @standard_promotion_time
-		effect = {
-			pop_amount_change_category = {
-				CATEGORY = complex_drone
-				AMOUNT = local_pop_amount
-			}
-		}
-	}
 }
 
 pw_calculator_abyssal_crater_test_site = {
@@ -313,7 +292,6 @@ pw_calculator_abyssal_crater_test_site = {
 
 	weight = {
 		weight = @complex_drone_job_weight
-		mult = value:job_weights_research_modifier|JOB|pw_calculator_abyssal_crater_test_site|
 		modifier = {
 			factor = 0.9
 			exists = owner
@@ -324,14 +302,4 @@ pw_calculator_abyssal_crater_test_site = {
 	}
 
 	inline_script = "jobs/automodding_priority_research"
-
-	promotion = {
-		time = @standard_promotion_time
-		effect = {
-			pop_amount_change_category = {
-				CATEGORY = complex_drone
-				AMOUNT = local_pop_amount
-			}
-		}
-	}
 }

--- a/common/script_values/pw_script_values.txt
+++ b/common/script_values/pw_script_values.txt
@@ -114,7 +114,7 @@ pw_mining_district_count = {
 	complex_trigger_modifier = {
 		trigger = num_districts
 		parameters = {
-			type = district_mining_uncapped
+			type = district_melting
 		}
 		mode = add
 		mult = $MULT|1$
@@ -146,7 +146,7 @@ pw_generator_district_count = {
 	complex_trigger_modifier = {
 		trigger = num_districts
 		parameters = {
-			type = district_generator_uncapped
+			type = district_geothermal
 		}
 		mode = add
 		mult = $MULT|1$
@@ -170,15 +170,6 @@ pw_farming_district_count = {
 		trigger = num_districts
 		parameters = {
 			type = district_rw_farming
-		}
-		mode = add
-		mult = $MULT|1$
-	}
-
-	complex_trigger_modifier = {
-		trigger = num_districts
-		parameters = {
-			type = district_farming_uncapped
 		}
 		mode = add
 		mult = $MULT|1$
@@ -260,7 +251,6 @@ pw_farming_value = {
 pw_farming_districts_value = {
 	# Normal
 	add = value:pw_districts_value|TYPE|district_farming|
-	add = value:pw_districts_value|TYPE|district_farming_uncapped|
 	# RW
 	add = value:pw_districts_value|TYPE|district_rw_farming|FACTOR|4|
 	# Evolved
@@ -283,7 +273,7 @@ pw_mining_value = {
 pw_mining_districts_value = {
 	# Normal
 	add = value:pw_districts_value|TYPE|district_mining|
-	add = value:pw_districts_value|TYPE|district_mining_uncapped|
+	add = value:pw_districts_value|TYPE|district_melting|
 	add = value:pw_districts_value|TYPE|district_hab_mining|
 	# Evolved
 	add = value:pw_mining_districts_value_evolved
@@ -307,7 +297,7 @@ pw_generators_value = {
 pw_generators_districts_value = {
 	# Normal
 	add = value:pw_districts_value|TYPE|district_generator|
-	add = value:pw_districts_value|TYPE|district_generator_uncapped|
+	add = value:pw_districts_value|TYPE|district_geothermal|
 	add = value:pw_districts_value|TYPE|district_hab_energy|
 	# RW
 	add = value:pw_districts_value|TYPE|district_rw_generator|FACTOR|4|

--- a/common/scripted_triggers/pw_scripted_triggers.txt
+++ b/common/scripted_triggers/pw_scripted_triggers.txt
@@ -221,7 +221,7 @@ pw_wonder_unique_elsewhere = {
 	# all(x) = not any (not x)
 	NOT = { 
 		any_owned_planet = {
-			NOT = { is_planet = root }
+			NOT = { is_same_value = root }
 			OR = {
 				has_building = $WONDER$
 				has_building_construction = $WONDER$

--- a/common/solar_system_initializers/pw_solar_system_initilizers.txt
+++ b/common/solar_system_initializers/pw_solar_system_initilizers.txt
@@ -18,14 +18,6 @@ pw_capricorns_heart_system_initializer = {
 	max_instances = 1
 	usage_odds = {
 		base = 0
-		modifier = {
-			add = 2000000
-			NOR = {
-				is_fe_cluster = yes
-				is_marauder_cluster = yes
-				has_star_flag = empire_cluster
-			}
-		}
 	}
 
 	planet = {
@@ -56,9 +48,9 @@ pw_capricorns_heart_system_initializer = {
 		modifiers = none
 		init_effect = {
 			prevent_anomaly = yes
-			set_planet_flag = pw_aligned_galactic_model_tomb_world
-			set_planet_flag = colony_event #Prevents Random colony events
-			set_planet_flag = nuked_planet_anomalies_disabled #Prevents further anomalies
+			set_carrier_flag = pw_aligned_galactic_model_tomb_world
+			set_carrier_flag = colony_event #Prevents Random colony events
+			set_carrier_flag = nuked_planet_anomalies_disabled #Prevents further anomalies
 			#add_building = pw_building_polyhedron
 		}
 		moon = {

--- a/common/special_projects/pw_special_projects.txt
+++ b/common/special_projects/pw_special_projects.txt
@@ -154,7 +154,7 @@ special_project = {
 	event_scope = planet_event
 
 	on_success = {
-		planet_event = { id = pw_wonder.1013 }
+		carrier_event = { id = pw_wonder.1013 }
 	}
 }
 
@@ -169,7 +169,7 @@ special_project = {
 	event_scope = planet_event
 
 	on_success = {
-		planet_event = { id = pw_wonder.1372 }
+		carrier_event = { id = pw_wonder.1372 }
 	}
 }
 
@@ -402,7 +402,7 @@ special_project = {
 	event_scope = planet_event
 
 	on_success = {
-		planet_event = { id = pw_grand_archive.105 }
+		carrier_event = { id = pw_grand_archive.105 }
 	}
 }
 #ARK Project (Frozen specimen, any barren cold or frozen planet)
@@ -517,7 +517,7 @@ special_project = {
 	event_scope = planet_event
 
 	on_success = {
-		planet_event = { id = pw_grand_archive.306 }
+		carrier_event = { id = pw_grand_archive.306 }
 	}
 }
 
@@ -555,7 +555,7 @@ special_project = {
 	event_scope = planet_event
 
 	on_success = {
-		planet_event = { id = pw_grand_archive.308 }
+		carrier_event = { id = pw_grand_archive.308 }
 	}
 }
 
@@ -593,7 +593,7 @@ special_project = {
 	event_scope = planet_event
 
 	on_success = {
-		planet_event = { id = pw_grand_archive.310 }
+		carrier_event = { id = pw_grand_archive.310 }
 	}
 }
 
@@ -631,7 +631,7 @@ special_project = {
 	event_scope = planet_event
 
 	on_success = {
-		planet_event = { id = pw_grand_archive.312 }
+		carrier_event = { id = pw_grand_archive.312 }
 	}
 }
 
@@ -724,7 +724,7 @@ special_project = {
 	event_scope = planet_event
 
 	on_success = {
-		planet_event = { id = pw_grand_archive.606 }
+		carrier_event = { id = pw_grand_archive.606 }
 	}
 }
 
@@ -740,7 +740,7 @@ special_project = {
 	event_scope = ship_event
 
 	requirements = {
-		fleet_power = 1500
+		fleet_power >= 1500
 	}
 
 	on_success = {
@@ -797,7 +797,7 @@ special_project = {
 	event_scope = planet_event
 
 	on_success = {
-		planet_event = { id = pw_grand_archive.905 }
+		carrier_event = { id = pw_grand_archive.905 }
 	}
 }
 
@@ -814,7 +814,7 @@ special_project = {
 	event_scope = planet_event
 
 	on_success = {
-		planet_event = { id = pw_grand_archive.906 }
+		carrier_event = { id = pw_grand_archive.906 }
 	}
 }
 
@@ -831,6 +831,6 @@ special_project = {
 	event_scope = planet_event
 
 	on_success = {
-		planet_event = { id = pw_grand_archive.907 }
+		carrier_event = { id = pw_grand_archive.907 }
 	}
 }

--- a/common/static_modifiers/pw_art_exhibition_modifiers.txt
+++ b/common/static_modifiers/pw_art_exhibition_modifiers.txt
@@ -312,7 +312,7 @@ pw_art_mod_elite_fragrance = {
 pw_art_mod_hostile_architecture = {
 	icon = "gfx/interface/icons/modifiers/mod_pop_amenities_usage_mult.dds"
 	pop_cat_worker_political_power = -0.1
-	pop_cat_slave_political_power = -0.1
+	pop_slave_political_power = -0.1
 }
 
 pw_art_mod_luxury_desire = {

--- a/common/technology/pw_techs.txt
+++ b/common/technology/pw_techs.txt
@@ -13,6 +13,10 @@ pw_tech_planetary_mega_engineering = {
 	weight = @tier4weight2
 	is_rare = yes
 
+	potential = {
+		is_nomadic = no
+	}
+
 	prereqfor_desc = {
 		custom = {
 			title = pw_prereq_planetary_wonders

--- a/common/war_goals/pw_wargoals.txt
+++ b/common/war_goals/pw_wargoals.txt
@@ -7,7 +7,7 @@
 wg_pw_r_coin_of_fortune = {
 	casus_belli = cb_pw_r_coin_of_fortune
 
-	hide_if_no_cb = yes
+	hide = no_cb
 	release_occupied_systems_on_status_quo = no
 
 	# forbidden_peace_offers = {}

--- a/events/pw_archaeological_events.txt
+++ b/events/pw_archaeological_events.txt
@@ -3,7 +3,7 @@ namespace = pw_archaeology
 #Gateway event for archaeology site after a blocker is cleared:
 #	- Forgotten Reliquary
 #	- Hidden Factory
-planet_event = {
+carrier_event = {
 	id = pw_archaeology.10
 	hide_window = yes
 
@@ -12,7 +12,7 @@ planet_event = {
 	trigger = {
 		NOT = { is_homeworld = yes }
 		NOT = { exists = archaeological_site }
-		NOT = { has_planet_flag = suppress_archaeological_sites }
+		NOT = { has_carrier_flag = suppress_archaeological_sites }
 		From = {
 			OR = {
 				is_deposit_type = d_deep_sinkhole
@@ -39,7 +39,7 @@ planet_event = {
 						has_country_flag = triggered_forgotten_reliquary_digsite
 					}
 				}
-				planet_event = { id = pw_archaeology.501 days = 1 }
+				carrier_event = { id = pw_archaeology.501 days = 1 }
 				owner = {
 					set_country_flag = triggered_forgotten_reliquary_digsite
 				}
@@ -51,7 +51,7 @@ planet_event = {
 						has_country_flag = triggered_hidden_factory_digsite
 					}
 				}
-				planet_event = { id = pw_archaeology.601 days = 1 }
+				carrier_event = { id = pw_archaeology.601 days = 1 }
 				owner = {
 					set_country_flag = triggered_hidden_factory_digsite
 				}
@@ -1180,7 +1180,7 @@ country_event = {
 ## Archaeology: Forgotten Reliquary -> 500
 
 # Site Discovery (after blocker was clear)
-planet_event = {
+carrier_event = {
 	id = pw_archaeology.501
 	title = pw_archaeology.501.name
 	desc = pw_archaeology.501.desc
@@ -1786,14 +1786,21 @@ country_event = {
 	option = {
 		name = pw_holy_reliquary.good_luck.a
 		capital_scope = {
-			while = {
-				count = 2
-				create_pop = {
-					ethos = {
-						ethic = ethic_spiritualist
-					}
-					species = this.owner_main_species
+			# while = {
+			# 	count = 2
+			# 	create_pop = {
+			# 		ethos = {
+			# 			ethic = ethic_spiritualist
+			# 		}
+			# 		species = this.owner_main_species
+			# 	}
+			# }
+			create_pop_group = {
+				size = 200
+				ethos = {
+					ethic = ethic_spiritualist
 				}
+				species = this.owner_main_species
 			}
 		}
 	}
@@ -2202,7 +2209,7 @@ country_event = {
 ## Archaeology: Hidden Factory -> 600
 
 # Site Discovery (after blocker was clear)
-planet_event = {
+carrier_event = {
 	id = pw_archaeology.601
 	title = pw_archaeology.601.name
 	desc = pw_archaeology.601.desc

--- a/events/pw_art_exhibition_events.txt
+++ b/events/pw_art_exhibition_events.txt
@@ -1,7 +1,7 @@
 namespace = pw_art_exhibition
 
 #Organize Planetary Exhibition
-planet_event = {
+carrier_event = {
 	id = pw_art_exhibition.1
 	title = pw_art_exhibition.1.name
 	desc = pw_art_exhibition.1.desc
@@ -1683,7 +1683,7 @@ country_event = {
 }
 
 #Organize Planetary Xenophile Exhibition
-planet_event = {
+carrier_event = {
 	id = pw_art_exhibition.4
 	title = pw_art_exhibition.4.name
 	desc = pw_art_exhibition.4.desc
@@ -3629,7 +3629,7 @@ country_event = {
 }
 
 #Organize Planetary Xenophobe Exhibition
-planet_event = {
+carrier_event = {
 	id = pw_art_exhibition.7
 	title = pw_art_exhibition.7.name
 	desc = pw_art_exhibition.7.desc

--- a/events/pw_branch_office_events.txt
+++ b/events/pw_branch_office_events.txt
@@ -5,7 +5,7 @@ namespace = pw_branch_office
 
 # Bloodsports Arena -> 110
 #On Bloodsports Arena built (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.110
 	hide_window = yes
 	is_triggered_only = yes
@@ -28,7 +28,7 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_branch_office.111 } #First time owner
+		carrier_event = { id = pw_branch_office.111 } #First time owner
 		if = {
 			limit = { exists = branch_office_owner }
 			branch_office_owner = {
@@ -39,7 +39,7 @@ planet_event = {
 }
 
 #First time Bloodsports Arena is build (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.111
 	title = pw_branch_office.111.name
 	desc = pw_branch_office.111.desc
@@ -151,7 +151,7 @@ country_event = {
 
 # Meditation Garden -> 120
 #On Meditation Garden built (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.120
 	hide_window = yes
 	is_triggered_only = yes
@@ -174,7 +174,7 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_branch_office.121 } #First time owner
+		carrier_event = { id = pw_branch_office.121 } #First time owner
 		if = {
 			limit = { exists = branch_office_owner }
 			branch_office_owner = {
@@ -185,7 +185,7 @@ planet_event = {
 }
 
 #First time Meditation Garden is build (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.121
 	title = pw_branch_office.121.name
 	desc = pw_branch_office.121.desc
@@ -297,7 +297,7 @@ country_event = {
 
 # Innovation Hub -> 130
 #On Innovation Hub built (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.130
 	hide_window = yes
 	is_triggered_only = yes
@@ -320,7 +320,7 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_branch_office.131 } #First time owner
+		carrier_event = { id = pw_branch_office.131 } #First time owner
 		if = {
 			limit = { exists = branch_office_owner }
 			branch_office_owner = {
@@ -331,7 +331,7 @@ planet_event = {
 }
 
 #First time Innovation Hub is build (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.131
 	title = pw_branch_office.131.name
 	desc = pw_branch_office.131.desc
@@ -443,7 +443,7 @@ country_event = {
 
 # Salvation Shrine -> 140
 #On Salvation Shrine built (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.140
 	hide_window = yes
 	is_triggered_only = yes
@@ -466,7 +466,7 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_branch_office.141 } #First time owner
+		carrier_event = { id = pw_branch_office.141 } #First time owner
 		if = {
 			limit = { exists = branch_office_owner }
 			branch_office_owner = {
@@ -477,7 +477,7 @@ planet_event = {
 }
 
 #First time Salvation Shrine is build (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.141
 	title = pw_branch_office.141.name
 	desc = pw_branch_office.141.desc
@@ -618,7 +618,7 @@ country_event = {
 
 # Exotic Beauty Center -> 150
 #On Exotic Beauty Center built (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.150
 	hide_window = yes
 	is_triggered_only = yes
@@ -641,7 +641,7 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_branch_office.151 } #First time owner
+		carrier_event = { id = pw_branch_office.151 } #First time owner
 		if = {
 			limit = { exists = branch_office_owner }
 			branch_office_owner = {
@@ -652,7 +652,7 @@ planet_event = {
 }
 
 #First time Exotic Beauty Center is build (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.151
 	title = pw_branch_office.151.name
 	desc = pw_branch_office.151.desc
@@ -761,7 +761,7 @@ country_event = {
 
 # National Pride Gallery -> 160
 #On National Pride Gallery built (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.160
 	hide_window = yes
 	is_triggered_only = yes
@@ -784,7 +784,7 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_branch_office.161 } #First time owner
+		carrier_event = { id = pw_branch_office.161 } #First time owner
 		if = {
 			limit = { exists = branch_office_owner }
 			branch_office_owner = {
@@ -795,7 +795,7 @@ planet_event = {
 }
 
 #First time National Pride Gallery is build (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.161
 	title = pw_branch_office.161.name
 	desc = pw_branch_office.161.desc
@@ -904,7 +904,7 @@ country_event = {
 
 # Aristocracy Tower -> 170
 #On Aristocracy Tower built (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.170
 	hide_window = yes
 	is_triggered_only = yes
@@ -927,7 +927,7 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_branch_office.171 } #First time owner
+		carrier_event = { id = pw_branch_office.171 } #First time owner
 		if = {
 			limit = { exists = branch_office_owner }
 			branch_office_owner = {
@@ -938,7 +938,7 @@ planet_event = {
 }
 
 #First time Aristocracy Tower is build (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.171
 	title = pw_branch_office.171.name
 	desc = pw_branch_office.171.desc
@@ -1047,7 +1047,7 @@ country_event = {
 
 # Factory City -> 180
 #On Factory City built (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.180
 	hide_window = yes
 	is_triggered_only = yes
@@ -1070,7 +1070,7 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_branch_office.181 } #First time owner
+		carrier_event = { id = pw_branch_office.181 } #First time owner
 		if = {
 			limit = { exists = branch_office_owner }
 			branch_office_owner = {
@@ -1081,7 +1081,7 @@ planet_event = {
 }
 
 #First time Factory City is build (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.181
 	title = pw_branch_office.181.name
 	desc = pw_branch_office.181.desc
@@ -1190,7 +1190,7 @@ country_event = {
 
 # Tax Haven -> 190
 #On Tax Haven built (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.190
 	hide_window = yes
 	is_triggered_only = yes
@@ -1213,7 +1213,7 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_branch_office.191 } #First time owner
+		carrier_event = { id = pw_branch_office.191 } #First time owner
 		if = {
 			limit = { exists = branch_office_owner }
 			branch_office_owner = {
@@ -1224,7 +1224,7 @@ planet_event = {
 }
 
 #First time Tax Haven is build (owner)
-planet_event = {
+carrier_event = {
 	id = pw_branch_office.191
 	title = pw_branch_office.191.name
 	desc = pw_branch_office.191.desc

--- a/events/pw_grand_archive_events.txt
+++ b/events/pw_grand_archive_events.txt
@@ -652,7 +652,7 @@ country_event = {
 }
 
 #Complete seed bank:
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.105
 	title = pw_grand_archive.105.name
 	desc = pw_grand_archive.105.desc
@@ -1228,7 +1228,7 @@ ship_event = {
 }
 
 #Complete wet planet (replaced):
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.306
 	title = pw_grand_archive.305.name
 	desc = pw_grand_archive.305.desc
@@ -1308,7 +1308,7 @@ ship_event = {
 }
 
 #Complete cold planet (replaced):
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.308
 	title = pw_grand_archive.307.name
 	desc = pw_grand_archive.307.desc
@@ -1388,7 +1388,7 @@ ship_event = {
 }
 
 #Complete dry planet (replaced):
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.310
 	title = pw_grand_archive.309.name
 	desc = pw_grand_archive.309.desc
@@ -1468,7 +1468,7 @@ ship_event = {
 }
 
 #Complete exotic planet (replaced):
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.312
 	title = pw_grand_archive.311.name
 	desc = pw_grand_archive.311.desc
@@ -2053,15 +2053,15 @@ country_event = {
 					limit = {
 						any_planet_within_border = {
 							is_star = yes
-							NOT = { has_planet_flag = pw_grand_archive_star_project }
+							NOT = { has_carrier_flag = pw_grand_archive_star_project }
 						}
 					}
 					random_planet_within_border = {
 						limit = {
 							is_star = yes
-							NOT = { has_planet_flag = pw_grand_archive_star_project }
+							NOT = { has_carrier_flag = pw_grand_archive_star_project }
 						}
-						set_planet_flag = pw_grand_archive_star_project
+						set_carrier_flag = pw_grand_archive_star_project
 						enable_special_project = {
 							name = PW_STELLARIUM_STAR
 							location = this
@@ -2131,7 +2131,7 @@ ship_event = {
 }
 
 #Complete star simulation:
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.606
 	title = pw_grand_archive.606.name
 	desc = pw_grand_archive.606.desc
@@ -2792,7 +2792,7 @@ country_event = {
 }
 
 #Complete Space Elevator:
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.905
 	title = pw_grand_archive.905.name
 	desc = pw_grand_archive.905.desc
@@ -2832,7 +2832,7 @@ planet_event = {
 }
 
 #Complete Astronomical Model Bureau:
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.906
 	title = pw_grand_archive.906.name
 	desc = pw_grand_archive.906.desc
@@ -2872,7 +2872,7 @@ planet_event = {
 }
 
 #Complete Guardian Angel:
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.907
 	title = pw_grand_archive.907.name
 	desc = pw_grand_archive.907.desc
@@ -3186,7 +3186,7 @@ country_event = {
 }
 
 #Add deposits for AI -> 1101
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.1101
 	hide_window = yes
 	is_triggered_only = yes
@@ -3201,14 +3201,14 @@ planet_event = {
 			add_deposit = pw_d_ark_project
 		}
 
-		planet_event = {
+		carrier_event = {
 			id = pw_grand_archive.1102
 			days = @pw_5years
 		}
 	}
 }
 
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.1102
 	hide_window = yes
 	is_triggered_only = yes
@@ -3223,14 +3223,14 @@ planet_event = {
 			add_deposit = pw_d_cradle_initiative
 		}
 
-		planet_event = {
+		carrier_event = {
 			id = pw_grand_archive.1103
 			days = @pw_5years
 		}
 	}
 }
 
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.1103
 	hide_window = yes
 	is_triggered_only = yes
@@ -3245,14 +3245,14 @@ planet_event = {
 			add_deposit = pw_d_library_of_babel
 		}
 
-		planet_event = {
+		carrier_event = {
 			id = pw_grand_archive.1104
 			days = @pw_5years
 		}
 	}
 }
 
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.1104
 	hide_window = yes
 	is_triggered_only = yes
@@ -3267,14 +3267,14 @@ planet_event = {
 			add_deposit = pw_d_particle_museum
 		}
 
-		planet_event = {
+		carrier_event = {
 			id = pw_grand_archive.1105
 			days = @pw_5years
 		}
 	}
 }
 
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.1105
 	hide_window = yes
 	is_triggered_only = yes
@@ -3289,14 +3289,14 @@ planet_event = {
 			add_deposit = pw_d_omnidatabase
 		}
 
-		planet_event = {
+		carrier_event = {
 			id = pw_grand_archive.1106
 			days = @pw_5years
 		}
 	}
 }
 
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.1106
 	hide_window = yes
 	is_triggered_only = yes
@@ -3311,14 +3311,14 @@ planet_event = {
 			add_deposit = pw_d_stellarium
 		}
 
-		planet_event = {
+		carrier_event = {
 			id = pw_grand_archive.1107
 			days = @pw_5years
 		}
 	}
 }
 
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.1107
 	hide_window = yes
 	is_triggered_only = yes
@@ -3333,14 +3333,14 @@ planet_event = {
 			add_deposit = pw_d_zero_g_exposition
 		}
 
-		planet_event = {
+		carrier_event = {
 			id = pw_grand_archive.1108
 			days = @pw_5years
 		}
 	}
 }
 
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.1108
 	hide_window = yes
 	is_triggered_only = yes
@@ -3355,14 +3355,14 @@ planet_event = {
 			add_deposit = pw_d_mechanist_collection
 		}
 
-		planet_event = {
+		carrier_event = {
 			id = pw_grand_archive.1109
 			days = @pw_5years
 		}
 	}
 }
 
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.1109
 	hide_window = yes
 	is_triggered_only = yes
@@ -3377,14 +3377,14 @@ planet_event = {
 			add_deposit = pw_d_meta_architectural_complex
 		}
 
-		planet_event = {
+		carrier_event = {
 			id = pw_grand_archive.1110
 			days = @pw_5years
 		}
 	}
 }
 
-planet_event = {
+carrier_event = {
 	id = pw_grand_archive.1110
 	hide_window = yes
 	is_triggered_only = yes

--- a/events/pw_holy_reliquary_events.txt
+++ b/events/pw_holy_reliquary_events.txt
@@ -1490,14 +1490,12 @@ country_event = {
 	option = {
 		name = pw_holy_reliquary.good_luck.a
 		capital_scope = {
-			while = {
-				count = 2
-				create_pop = {
-					ethos = {
-						ethic = ethic_spiritualist
-					}
-					species = this.owner_main_species
+			create_pop_group = {
+				size = 200
+				ethos = {
+					ethic = ethic_spiritualist
 				}
+				species = this.owner_main_species
 			}
 		}
 		pw_holy_reliquary_return_to_hub = yes
@@ -4310,7 +4308,8 @@ country_event = {
 			energy = -1500
 		}
 		event_target:pw_holy_reliquary_planet = {
-			create_pop = {
+			create_pop_group = {
+				size = 100
 				species = owner
 			}
 		}

--- a/events/pw_wonder_events.txt
+++ b/events/pw_wonder_events.txt
@@ -15,7 +15,7 @@ country_event = {
 
 #Message for wonder construction complete
 # UNUSED!
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1
 	hide_window = yes
 	is_triggered_only = yes
@@ -78,7 +78,7 @@ country_event = {
 # Space Elevator -> id 100
 
 #On Space Elevator built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.100
 	hide_window = yes
 	is_triggered_only = yes
@@ -100,14 +100,14 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.101 }
-		planet_event = { id = pw_wonder.102 }
-		planet_event = { id = pw_wonder.103 days = 5 }
+		carrier_event = { id = pw_wonder.101 }
+		carrier_event = { id = pw_wonder.102 }
+		carrier_event = { id = pw_wonder.103 days = 5 }
 	}
 }
 
 #On first time Space Elevator is built (regular empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.101
 	title = pw_wonder.101.name
 	desc = pw_wonder.101.desc
@@ -195,7 +195,7 @@ planet_event = {
 }
 
 #On first time Space Elevator is built (gestalt)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.102
 	title = pw_wonder.102.name
 	desc = pw_wonder.102.desc
@@ -299,7 +299,7 @@ planet_event = {
 }
 
 #Random choice of event after Space Elevator is build.
-planet_event = {
+carrier_event = {
 	id = pw_wonder.103
 	hide_window = yes
 	is_triggered_only = yes
@@ -315,31 +315,31 @@ planet_event = {
 					factor = 0
 					owner = { is_gestalt = yes }
 				}
-				planet_event = { id = pw_wonder.104 days = 180 random = 180 }
+				carrier_event = { id = pw_wonder.104 days = 180 random = 180 }
 			}
 			10 = {
 				modifier = {
 					factor = 0
 					owner = { is_gestalt = yes }
 				}
-				planet_event = { id = pw_wonder.105 days = 180 random = 180 }
+				carrier_event = { id = pw_wonder.105 days = 180 random = 180 }
 			}
 			10 = {
 				modifier = {
 					factor = 0
 					owner = { is_gestalt = yes }
 				}
-				planet_event = { id = pw_wonder.106 days = 180 random = 180 }
+				carrier_event = { id = pw_wonder.106 days = 180 random = 180 }
 			}
 			10 = {
-				planet_event = { id = pw_wonder.107 days = 180 random = 180 }
+				carrier_event = { id = pw_wonder.107 days = 180 random = 180 }
 			}
 		}
 	}
 }
 
 #Seize unregulated goods
-planet_event = {
+carrier_event = {
 	id = pw_wonder.104
 	title = pw_wonder.104.name
 	desc = pw_wonder.104.desc
@@ -380,7 +380,7 @@ planet_event = {
 }
 
 #Banned Substances
-planet_event = {
+carrier_event = {
 	id = pw_wonder.105
 	title = pw_wonder.105.name
 	desc = pw_wonder.105.desc
@@ -411,7 +411,7 @@ planet_event = {
 }
 
 #Stowaways
-planet_event = {
+carrier_event = {
 	id = pw_wonder.106
 	title = pw_wonder.106.name
 	desc = pw_wonder.106.desc
@@ -429,7 +429,11 @@ planet_event = {
 	}
 	option = {
 		name = pw_wonder.106.a
-		create_pop = {
+		# create_pop = {
+		# 	species = owner
+		# }
+		create_pop_group = {
+			size = 100
 			species = owner
 		}
 	}
@@ -472,7 +476,7 @@ planet_event = {
 }
 
 #Kessler Effect -> Convert to situation!
-planet_event = {
+carrier_event = {
 	id = pw_wonder.107
 	title = pw_wonder.107.name
 	desc = pw_wonder.107.desc
@@ -572,7 +576,7 @@ planet_event = {
 }
 
 #Help Development
-planet_event = {
+carrier_event = {
 	id = pw_wonder.110
 	title = pw_wonder.110.name
 	desc = pw_wonder.110.desc
@@ -632,7 +636,7 @@ planet_event = {
 }
 
 #Help Development (Finish Colonization)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.111
 	title = pw_wonder.111.name
 	desc = pw_wonder.111.desc
@@ -660,7 +664,7 @@ planet_event = {
 }
 
 #On both Skyhook and Space Ramp have been constructed
-planet_event = {
+carrier_event = {
 	id = pw_wonder.120
 	title = pw_wonder.120.name
 	desc = pw_wonder.120.desc
@@ -701,7 +705,7 @@ planet_event = {
 }
 
 #On counterweigh habitat is colonized
-# planet_event = {
+# carrier_event = {
 # 	id = pw_wonder.121
 # 	hide_window = yes
 # 	is_triggered_only = yes
@@ -730,7 +734,7 @@ planet_event = {
 # }
 
 #Open for Galactic Market decision
-planet_event = {
+carrier_event = {
 	id = pw_wonder.130
 	title = pw_wonder.130.name
 	desc = pw_wonder.130.desc
@@ -739,12 +743,12 @@ planet_event = {
 	location = this
 
 	immediate = {
-		set_planet_flag = pw_SE_is_choosing_market_bonus
+		set_carrier_flag = pw_SE_is_choosing_market_bonus
 	}
 
 	trigger = {
 		has_active_building = pw_building_space_elevator
-		NOT = { has_planet_flag = pw_SE_is_choosing_market_bonus }
+		NOT = { has_carrier_flag = pw_SE_is_choosing_market_bonus }
 	}
 
 	option = {
@@ -895,7 +899,7 @@ planet_event = {
 
 	after = {
 		hidden_effect = {
-			remove_planet_flag = pw_SE_is_choosing_market_bonus
+			remove_carrier_flag = pw_SE_is_choosing_market_bonus
 		}
 	}
 }
@@ -903,7 +907,7 @@ planet_event = {
 # Particle Supercollider -> id 200
 
 #On Particle Supercollider built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.200
 	hide_window = yes
 	is_triggered_only = yes
@@ -925,8 +929,8 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.201 }
-		planet_event = { id = pw_wonder.202 }
+		carrier_event = { id = pw_wonder.201 }
+		carrier_event = { id = pw_wonder.202 }
 		owner = { country_event = { #Subject/Overlord events
 			id = pw_wonder.203
 			days = 10
@@ -935,7 +939,7 @@ planet_event = {
 }
 
 #On first time Particle Supercollider is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.201
 	title = pw_wonder.201.name
 	desc = pw_wonder.201.desc
@@ -1014,7 +1018,7 @@ planet_event = {
 }
 
 #On first time Particle Supercollider is built (Gestalt)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.202
 	title = pw_wonder.202.name
 	desc = pw_wonder.202.desc
@@ -1162,7 +1166,7 @@ country_event = {
 # Interdimensional Collider -> id 250
 
 #On Interdimensional Collider built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.250
 	hide_window = yes
 	is_triggered_only = yes
@@ -1189,12 +1193,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.251 } #first time
+		carrier_event = { id = pw_wonder.251 } #first time
 	}
 }
 
 #On first time Interdimensional Collider is built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.251
 	title = pw_wonder.251.name
 	desc = pw_wonder.251.desc
@@ -1229,7 +1233,7 @@ planet_event = {
 	}
 
 	after = {
-		planet_event = {
+		carrier_event = {
 			id = pw_wonder.255
 			days = 10
 		}
@@ -1237,7 +1241,7 @@ planet_event = {
 }
 
 #Explanation that Particle Supercollider can still be built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.255
 	title = pw_wonder.255.name
 	desc = pw_wonder.255.desc
@@ -1259,7 +1263,7 @@ planet_event = {
 # Domed City -> id 300
 
 #On Domed City built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.300
 	hide_window = yes
 	is_triggered_only = yes
@@ -1297,13 +1301,13 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.301 }
-		planet_event = { id = pw_wonder.302 }
+		carrier_event = { id = pw_wonder.301 }
+		carrier_event = { id = pw_wonder.302 }
 	}
 }
 
 #On first time Domed City is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.301
 	title = pw_wonder.301.name
 	desc = {
@@ -1432,7 +1436,7 @@ planet_event = {
 }
 
 #On first time Domed City is built (Gestalt)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.302
 	title = pw_wonder.302.name
 	desc = {
@@ -1543,7 +1547,7 @@ planet_event = {
 # Psionic Observatory -> id 350
 
 #On Psionic Observatory built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.350
 	hide_window = yes
 	is_triggered_only = yes
@@ -1570,12 +1574,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.351 } #first time
+		carrier_event = { id = pw_wonder.351 } #first time
 	}
 }
 
 #On first time Psionic Observatory is built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.351
 	title = pw_wonder.351.name
 	desc = pw_wonder.351.desc
@@ -1636,7 +1640,7 @@ planet_event = {
 	}
 
 	after = {
-		planet_event = {
+		carrier_event = {
 			id = pw_wonder.355
 			days = 10
 		}
@@ -1644,7 +1648,7 @@ planet_event = {
 }
 
 #Explanation that Domed City can still be built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.355
 	title = pw_wonder.355.name
 	desc = pw_wonder.355.desc
@@ -1665,7 +1669,7 @@ planet_event = {
 # Abyssal Crater Test Site -> id 400
 
 #On Abyssal Crater Test Site built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.400
 	hide_window = yes
 	is_triggered_only = yes
@@ -1703,13 +1707,13 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.401 }
-		planet_event = { id = pw_wonder.402 }
+		carrier_event = { id = pw_wonder.401 }
+		carrier_event = { id = pw_wonder.402 }
 	}
 }
 
 #On first time Abyssal Crater Test Site is built (regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.401
 	title = pw_wonder.401.name
 	desc = {
@@ -1799,7 +1803,7 @@ planet_event = {
 }
 
 #On first time Abyssal Crater Test Site is built (Gestalt)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.402
 	title = pw_wonder.402.name
 	desc = {
@@ -1881,7 +1885,7 @@ planet_event = {
 # Metal Vivarium -> id 450
 
 #On Metal Vivarium built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.450
 	hide_window = yes
 	is_triggered_only = yes
@@ -1908,12 +1912,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.451 } #first time
+		carrier_event = { id = pw_wonder.451 } #first time
 	}
 }
 
 #On first time Metal Vivarium is built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.451
 	title = pw_wonder.451.name
 	desc = pw_wonder.451.desc
@@ -1948,7 +1952,7 @@ planet_event = {
 	}
 
 	after = {
-		planet_event = {
+		carrier_event = {
 			id = pw_wonder.455
 			days = 10
 		}
@@ -1956,7 +1960,7 @@ planet_event = {
 }
 
 #Explanation that Abyssal Crater Test Site can still be built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.455
 	title = pw_wonder.455.name
 	desc = pw_wonder.455.desc
@@ -1978,7 +1982,7 @@ planet_event = {
 # Erebus Project -> id 500
 
 #On Erebus Project built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.500
 	hide_window = yes
 	is_triggered_only = yes
@@ -2000,13 +2004,13 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.501 }
-		planet_event = { id = pw_wonder.502 }
+		carrier_event = { id = pw_wonder.501 }
+		carrier_event = { id = pw_wonder.502 }
 	}
 }
 
 #On first time Erebus Project is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.501
 	title = pw_wonder.501.name
 	desc = pw_wonder.501.desc
@@ -2125,7 +2129,7 @@ planet_event = {
 }
 
 #On first time Erebus Project is built (Gestalt)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.502
 	title = pw_wonder.502.name
 	desc = pw_wonder.502.desc
@@ -2276,24 +2280,24 @@ planet_event = {
 }
 
 #Random Aggressive Prospecting effect
-planet_event = {
+carrier_event = {
 	id = pw_wonder.503
 	hide_window = yes
 	is_triggered_only = yes
 
 	trigger = {
-		NOT = { has_planet_flag = pw_aggressive_prospecting_event_triggered }
+		NOT = { has_carrier_flag = pw_aggressive_prospecting_event_triggered }
 		has_modifier = pw_mod_erebus_prospecting
 	}
 
 	immediate = {
 		if = {
 			limit = { #Exhausted mining options.
-				has_planet_flag = pw_aggressive_prospecting_crystal
-				has_planet_flag = pw_aggressive_prospecting_motes
-				has_planet_flag = pw_aggressive_prospecting_gases
+				has_carrier_flag = pw_aggressive_prospecting_crystal
+				has_carrier_flag = pw_aggressive_prospecting_motes
+				has_carrier_flag = pw_aggressive_prospecting_gases
 			}
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.510
 				days = 60
 				random = 30
@@ -2302,21 +2306,21 @@ planet_event = {
 		else = {
 			random_list = {
 				10 = {
-					planet_event = {
+					carrier_event = {
 						id = pw_wonder.504
 						days = 60
 						random = 30
 					}
 				}
 				10 = {
-					planet_event = {
+					carrier_event = {
 						id = pw_wonder.506
 						days = 60
 						random = 30
 					}
 				}
 				10 = {
-					planet_event = {
+					carrier_event = {
 						id = pw_wonder.508
 						days = 60
 						random = 30
@@ -2329,7 +2333,7 @@ planet_event = {
 }
 
 #Check if already added crystals
-planet_event = {
+carrier_event = {
 	id = pw_wonder.504
 	hide_window = yes
 	is_triggered_only = yes
@@ -2343,17 +2347,17 @@ planet_event = {
 	}
 	immediate = {
 		if = {
-			limit = { has_planet_flag = pw_aggressive_prospecting_crystal }
-			planet_event = { id = pw_wonder.503 }
+			limit = { has_carrier_flag = pw_aggressive_prospecting_crystal }
+			carrier_event = { id = pw_wonder.503 }
 		}
 		else = {
-			planet_event = { id = pw_wonder.505 }
+			carrier_event = { id = pw_wonder.505 }
 		}
 	}
 }
 
 #Aggressive Prospecting adds Crystals
-planet_event = {
+carrier_event = {
 	id = pw_wonder.505
 	title = pw_wonder.505.name
 	desc = pw_wonder.505.desc
@@ -2363,7 +2367,7 @@ planet_event = {
 	location = this
 
 	immediate = {
-		set_planet_flag = pw_aggressive_prospecting_crystal
+		set_carrier_flag = pw_aggressive_prospecting_crystal
 	}
 	trigger = {
 		OR = {
@@ -2382,7 +2386,7 @@ planet_event = {
 }
 
 #Check if already added motes
-planet_event = {
+carrier_event = {
 	id = pw_wonder.506
 	hide_window = yes
 	is_triggered_only = yes
@@ -2396,17 +2400,17 @@ planet_event = {
 	}
 	immediate = {
 		if = {
-			limit = { has_planet_flag = pw_aggressive_prospecting_motes }
-			planet_event = { id = pw_wonder.503 }
+			limit = { has_carrier_flag = pw_aggressive_prospecting_motes }
+			carrier_event = { id = pw_wonder.503 }
 		}
 		else = {
-			planet_event = { id = pw_wonder.507 }
+			carrier_event = { id = pw_wonder.507 }
 		}
 	}
 }
 
 #Aggressive Prospecting adds Motes
-planet_event = {
+carrier_event = {
 	id = pw_wonder.507
 	title = pw_wonder.507.name
 	desc = pw_wonder.507.desc
@@ -2416,7 +2420,7 @@ planet_event = {
 	location = this
 
 	immediate = {
-		set_planet_flag = pw_aggressive_prospecting_motes
+		set_carrier_flag = pw_aggressive_prospecting_motes
 	}
 	trigger = {
 		OR = {
@@ -2435,7 +2439,7 @@ planet_event = {
 }
 
 #Check if already added gases
-planet_event = {
+carrier_event = {
 	id = pw_wonder.508
 	hide_window = yes
 	is_triggered_only = yes
@@ -2449,17 +2453,17 @@ planet_event = {
 	}
 	immediate = {
 		if = {
-			limit = { has_planet_flag = pw_aggressive_prospecting_gases }
-			planet_event = { id = pw_wonder.503 }
+			limit = { has_carrier_flag = pw_aggressive_prospecting_gases }
+			carrier_event = { id = pw_wonder.503 }
 		}
 		else = {
-			planet_event = { id = pw_wonder.509 }
+			carrier_event = { id = pw_wonder.509 }
 		}
 	}
 }
 
 #Aggressive Prospecting adds gases
-planet_event = {
+carrier_event = {
 	id = pw_wonder.509
 	title = pw_wonder.509.name
 	desc = pw_wonder.509.desc
@@ -2469,7 +2473,7 @@ planet_event = {
 	location = this
 
 	immediate = {
-		set_planet_flag = pw_aggressive_prospecting_gases
+		set_carrier_flag = pw_aggressive_prospecting_gases
 	}
 	trigger = {
 		OR = {
@@ -2488,7 +2492,7 @@ planet_event = {
 }
 
 #Aggressive Prospecting adds Poor Mineral Quality
-planet_event = {
+carrier_event = {
 	id = pw_wonder.510
 	title = pw_wonder.510.name
 	desc = pw_wonder.510.desc
@@ -2504,7 +2508,7 @@ planet_event = {
 		}
 	}
 	immediate = {
-		set_planet_flag = pw_aggressive_prospecting_event_triggered
+		set_carrier_flag = pw_aggressive_prospecting_event_triggered
 	}
 	option = {
 		name = pw_wonder.510.a
@@ -2520,7 +2524,7 @@ planet_event = {
 # Erebus Fracking Plant -> id 550
 
 #On Erebus Fracking Plant built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.550
 	hide_window = yes
 	is_triggered_only = yes
@@ -2547,12 +2551,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.551 }
+		carrier_event = { id = pw_wonder.551 }
 	}
 }
 
 #On first time Erebus Fracking Plant is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.551
 	title = pw_wonder.551.name
 	desc = pw_wonder.551.desc
@@ -2635,7 +2639,7 @@ planet_event = {
 # Helios Tower -> id 600
 
 #On Helios Tower built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.600
 	hide_window = yes
 	is_triggered_only = yes
@@ -2657,13 +2661,13 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.601 }
-		planet_event = { id = pw_wonder.602 }
+		carrier_event = { id = pw_wonder.601 }
+		carrier_event = { id = pw_wonder.602 }
 	}
 }
 
 #On first time Helios Tower is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.601
 	title = pw_wonder.601.name
 	desc = pw_wonder.601.desc
@@ -2722,7 +2726,7 @@ planet_event = {
 }
 
 #On first time Helios Tower is built (Gestalt)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.602
 	title = pw_wonder.602.name
 	desc = pw_wonder.602.desc
@@ -2758,27 +2762,27 @@ planet_event = {
 }
 
 #Random Cloud Seeding effect
-planet_event = {
+carrier_event = {
 	id = pw_wonder.603
 	hide_window = yes
 	is_triggered_only = yes
 
 	trigger = {
-		NOT = { has_planet_flag = pw_cloud_seeding_event_triggered }
+		NOT = { has_carrier_flag = pw_cloud_seeding_event_triggered }
 	}
 
 	immediate = {
-		set_planet_flag = pw_cloud_seeding_event_triggered
+		set_carrier_flag = pw_cloud_seeding_event_triggered
 		random_list = {
 			10 = {
-				planet_event = {
+				carrier_event = {
 					id = pw_wonder.604
 					days = 60
 					random = 30
 				}
 			}
 			10 = {
-				planet_event = {
+				carrier_event = {
 					id = pw_wonder.605
 					days = 60
 					random = 30
@@ -2792,7 +2796,7 @@ planet_event = {
 						merg_is_hive_world = yes
 					}
 				}
-				planet_event = {
+				carrier_event = {
 					id = pw_wonder.606
 					days = 60
 					random = 30
@@ -2804,7 +2808,7 @@ planet_event = {
 }
 
 #Cloud Seeding adds Hazardous Weather
-planet_event = {
+carrier_event = {
 	id = pw_wonder.604
 	title = pw_wonder.604.name
 	desc = pw_wonder.604.desc
@@ -2845,7 +2849,7 @@ planet_event = {
 }
 
 #Cloud Seeding adds Wild Storms
-planet_event = {
+carrier_event = {
 	id = pw_wonder.605
 	title = pw_wonder.605.name
 	desc = pw_wonder.605.desc
@@ -2886,7 +2890,7 @@ planet_event = {
 }
 
 #Cloud Seeding adds Atmospheric Aphrodisiacs
-planet_event = {
+carrier_event = {
 	id = pw_wonder.606
 	title = pw_wonder.606.name
 	desc = pw_wonder.606.desc
@@ -2926,7 +2930,7 @@ planet_event = {
 # Helios Translucent Obelisk -> id 600
 
 #On Helios Translucent Obelisk built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.650
 	hide_window = yes
 	is_triggered_only = yes
@@ -2953,12 +2957,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.651 }
+		carrier_event = { id = pw_wonder.651 }
 	}
 }
 
 #On first time Helios Translucent Obelisk is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.651
 	title = pw_wonder.651.name
 	desc = pw_wonder.651.desc
@@ -3002,7 +3006,7 @@ planet_event = {
 # Demetrius Cornucopia -> id 700
 
 #On Demetrius Cornucopia built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.700
 	hide_window = yes
 	is_triggered_only = yes
@@ -3024,13 +3028,13 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.701 }
-		planet_event = { id = pw_wonder.702 }
+		carrier_event = { id = pw_wonder.701 }
+		carrier_event = { id = pw_wonder.702 }
 	}
 }
 
 #On first time Demetrius Cornucopia is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.701
 	title = pw_wonder.701.name
 	desc = {
@@ -3144,7 +3148,7 @@ planet_event = {
 }
 
 #On first time Demetrius Cornucopia is built (Gestalt)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.702
 	title = pw_wonder.702.name
 	desc = pw_wonder.702.desc
@@ -3224,41 +3228,41 @@ planet_event = {
 }
 
 #Random Predatory Harvesting effect
-planet_event = {
+carrier_event = {
 	id = pw_wonder.703
 	hide_window = yes
 	is_triggered_only = yes
 
 	trigger = {
-		NOT = { has_planet_flag = pw_predatory_harvesting_event_triggered }
+		NOT = { has_carrier_flag = pw_predatory_harvesting_event_triggered }
 	}
 
 	immediate = {
-		set_planet_flag = pw_predatory_harvesting_event_triggered
+		set_carrier_flag = pw_predatory_harvesting_event_triggered
 		random_list = {
 			10 = {
-				planet_event = {
+				carrier_event = {
 					id = pw_wonder.704
 					days = 60
 					random = 30
 				}
 			}
 			10 = {
-				planet_event = {
+				carrier_event = {
 					id = pw_wonder.705
 					days = 60
 					random = 30
 				}
 			}
 			10 = {
-				planet_event = {
+				carrier_event = {
 					id = pw_wonder.706
 					days = 60
 					random = 30
 				}
 			}
 			10 = {
-				planet_event = {
+				carrier_event = {
 					id = pw_wonder.707
 					days = 60
 					random = 30
@@ -3269,7 +3273,7 @@ planet_event = {
 					factor = 0 #Hive planets can't have Natural Beauty mod.
 					merg_is_hive_world = yes
 				}
-				planet_event = {
+				carrier_event = {
 					id = pw_wonder.708
 					days = 60
 					random = 30
@@ -3281,7 +3285,7 @@ planet_event = {
 }
 
 #Predatory Harvesting adds Lush
-planet_event = {
+carrier_event = {
 	id = pw_wonder.704
 	title = pw_wonder.704.name
 	desc = pw_wonder.704.desc
@@ -3322,7 +3326,7 @@ planet_event = {
 }
 
 #Predatory Harvesting adds Bleak
-planet_event = {
+carrier_event = {
 	id = pw_wonder.705
 	title = pw_wonder.705.name
 	desc = pw_wonder.705.desc
@@ -3370,7 +3374,7 @@ planet_event = {
 }
 
 #Predatory Harvesting adds Hostile Fauna
-planet_event = {
+carrier_event = {
 	id = pw_wonder.706
 	title = pw_wonder.706.name
 	desc = pw_wonder.706.desc
@@ -3411,7 +3415,7 @@ planet_event = {
 }
 
 #Predatory Harvesting adds Titanic Life
-planet_event = {
+carrier_event = {
 	id = pw_wonder.707
 	title = pw_wonder.707.name
 	desc = pw_wonder.707.desc
@@ -3452,7 +3456,7 @@ planet_event = {
 }
 
 #Predatory Harvesting adds Natural Beauty
-planet_event = {
+carrier_event = {
 	id = pw_wonder.708
 	title = pw_wonder.708.name
 	desc = pw_wonder.708.desc
@@ -3495,7 +3499,7 @@ planet_event = {
 # Demetrius Chemical Garden -> id 750
 
 #On Demetrius Chemical Garden built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.750
 	hide_window = yes
 	is_triggered_only = yes
@@ -3522,12 +3526,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.751 }
+		carrier_event = { id = pw_wonder.751 }
 	}
 }
 
 #On first time Demetrius Chemical Garden is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.751
 	title = pw_wonder.751.name
 	desc = pw_wonder.751.desc
@@ -3567,7 +3571,7 @@ planet_event = {
 }
 
 #Land Repurposing decision Event (every resource wonder)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.790
 	title = pw_wonder.790.name
 	desc = pw_wonder.790.desc
@@ -3585,11 +3589,11 @@ planet_event = {
 			has_active_building = pw_building_demetrius_fields
 			has_active_building = pw_building_demetrius_chemical_garden
 		}
-		NOT = { has_planet_flag = pw_is_managing_land_purpose }
+		NOT = { has_carrier_flag = pw_is_managing_land_purpose }
 	}
 
 	immediate = {
-		set_planet_flag = pw_is_managing_land_purpose
+		set_carrier_flag = pw_is_managing_land_purpose
 	}
 
 	option = {
@@ -3819,14 +3823,14 @@ planet_event = {
 	}
 
 	after = {
-		hidden_effect = { remove_planet_flag = pw_is_managing_land_purpose }
+		hidden_effect = { remove_carrier_flag = pw_is_managing_land_purpose }
 	}
 }
 
 # Astronomical Model Bureau -> id 800
 
 #On Astronomical Model Bureau built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.800
 	hide_window = yes
 	is_triggered_only = yes
@@ -3848,15 +3852,15 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.801 }
-		planet_event = { id = pw_wonder.802 }
-		planet_event = { id = pw_wonder.803 days = 90 random = 30 } #Event chain begin
+		carrier_event = { id = pw_wonder.801 }
+		carrier_event = { id = pw_wonder.802 }
+		carrier_event = { id = pw_wonder.803 days = 90 random = 30 } #Event chain begin
 		owner = { country_event = { id = pw_wonder.813 days = @pw_10years }} #Event chain ends (if there is any problems along the way)
 	}
 }
 
 #On first time Astronomical Model Bureau is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.801
 	title = pw_wonder.801.name
 	desc = pw_wonder.801.desc
@@ -3947,7 +3951,7 @@ planet_event = {
 }
 
 #On first time Astronomical Model Bureau is built (Gestalt)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.802
 	title = pw_wonder.802.name
 	desc = pw_wonder.802.desc
@@ -4008,7 +4012,7 @@ planet_event = {
 }
 
 #Tow asteroid
-planet_event = {
+carrier_event = {
 	id = pw_wonder.803
 	title = pw_wonder.803.name
 	desc = pw_wonder.803.desc
@@ -4519,7 +4523,7 @@ country_event = {
 				uninhabitable_regular_planet = yes
 				is_planet_class = pc_gas_giant
 			}
-			NOT = { is_planet = event_target:pw_resource_planet }
+			NOT = { is_same_value = event_target:pw_resource_planet }
 		}
 		any_owned_planet = {
 			OR = {
@@ -4538,7 +4542,7 @@ country_event = {
 					uninhabitable_regular_planet = yes
 					is_planet_class = pc_gas_giant
 				}
-				NOT = { is_planet = event_target:pw_resource_planet }
+				NOT = { is_same_value = event_target:pw_resource_planet }
 			}
 			save_event_target_as = pw_resource_planet
 		}
@@ -4899,7 +4903,7 @@ country_event = {
 # Aligned Galactic Model -> id 850
 
 #On Aligned Galactic Model built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.850
 	hide_window = yes
 	is_triggered_only = yes
@@ -4925,13 +4929,13 @@ planet_event = {
 				scope = root
 			}
 		}
-		planet_event = { id = pw_wonder.851 }
+		carrier_event = { id = pw_wonder.851 }
 		owner = { country_event = { id = pw_wonder.860 days = 60 }} #Spawn hidden system
 	}
 }
 
 #On first time Aligned Galactic Model is built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.851
 	title = pw_wonder.851.name
 	desc = pw_wonder.851.desc
@@ -5064,7 +5068,7 @@ ship_event = {
 
 	trigger = {
 		from = {
-			has_planet_flag = pw_aligned_galactic_model_tomb_world
+			has_carrier_flag = pw_aligned_galactic_model_tomb_world
 		}
 	}
 
@@ -5086,7 +5090,7 @@ ship_event = {
 }
 
 #After 3 years Tomb World in Unique System is colonized
-planet_event = {
+carrier_event = {
 	id = pw_wonder.865
 	title = pw_wonder.865.name
 	desc = pw_wonder.865.desc
@@ -5106,12 +5110,12 @@ planet_event = {
 
 	trigger = {
 		pop_amount > 0
-		has_planet_flag = pw_aligned_galactic_model_tomb_world
-		NOT = { has_planet_flag = pw_aligned_galactic_model_asteroid }
+		has_carrier_flag = pw_aligned_galactic_model_tomb_world
+		NOT = { has_carrier_flag = pw_aligned_galactic_model_asteroid }
 	}
 
 	immediate = {
-		set_planet_flag = pw_aligned_galactic_model_asteroid
+		set_carrier_flag = pw_aligned_galactic_model_asteroid
 		owner = {
 			set_country_flag = pw_aligned_galactic_model_asteroid
 		}
@@ -5169,7 +5173,7 @@ planet_event = {
 						effect = {
 							id = "pw_wonder.865.effect.1"
 							root = {
-								planet_event = { id = pw_wonder.868 }
+								carrier_event = { id = pw_wonder.868 }
 							}
 						}
 					}
@@ -5198,7 +5202,7 @@ planet_event = {
 						effect = {
 							id = "pw_wonder.865.effect.2"
 							root = {
-								planet_event = { id = pw_wonder.868 }
+								carrier_event = { id = pw_wonder.868 }
 							}
 						}
 					}
@@ -5227,7 +5231,7 @@ planet_event = {
 						effect = {
 							id = "pw_wonder.865.effect.3"
 							root = {
-								planet_event = { id = pw_wonder.868 }
+								carrier_event = { id = pw_wonder.868 }
 							}
 						}
 					}
@@ -5256,7 +5260,7 @@ planet_event = {
 						effect = {
 							id = "pw_wonder.865.effect.4"
 							root = {
-								planet_event = { id = pw_wonder.868 }
+								carrier_event = { id = pw_wonder.868 }
 							}
 						}
 					}
@@ -5285,7 +5289,7 @@ planet_event = {
 						effect = {
 							id = "pw_wonder.865.effect.5"
 							root = {
-								planet_event = { id = pw_wonder.868 }
+								carrier_event = { id = pw_wonder.868 }
 							}
 						}
 					}
@@ -5350,7 +5354,7 @@ country_event = {
 						flag = pw_asteroid_enemy
 					}
 				}
-				any_owned_planet = { has_planet_flag = pw_aligned_galactic_model_asteroid }
+				any_owned_planet = { has_carrier_flag = pw_aligned_galactic_model_asteroid }
 			}
 			add_event_chain_counter = {
 				event_chain = pw_multiple_asteroid_attack
@@ -5358,8 +5362,8 @@ country_event = {
 				amount = 1
 			}
 			random_owned_planet = {
-				limit = { has_planet_flag = pw_aligned_galactic_model_asteroid }
-				planet_event = { id = pw_wonder.867 }
+				limit = { has_carrier_flag = pw_aligned_galactic_model_asteroid }
+				carrier_event = { id = pw_wonder.867 }
 			}
 		}
 		else = {
@@ -5370,7 +5374,7 @@ country_event = {
 						flag = pw_asteroid_enemy
 					}
 					has_country_flag = pw_aligned_galactic_model_asteroid
-					any_owned_planet = { has_planet_flag = pw_aligned_galactic_model_asteroid }
+					any_owned_planet = { has_carrier_flag = pw_aligned_galactic_model_asteroid }
 				}
 				add_event_chain_counter = {
 					event_chain = pw_multiple_asteroid_attack
@@ -5378,8 +5382,8 @@ country_event = {
 					amount = 1
 				}
 				random_owned_planet = {
-					limit = { has_planet_flag = pw_aligned_galactic_model_asteroid }
-					planet_event = { id = pw_wonder.867 }
+					limit = { has_carrier_flag = pw_aligned_galactic_model_asteroid }
+					carrier_event = { id = pw_wonder.867 }
 				}
 			}
 		}
@@ -5387,7 +5391,7 @@ country_event = {
 }
 
 # All Asteroid Destroyed
-planet_event = {
+carrier_event = {
 	id = pw_wonder.867
 	title = pw_wonder.867.name
 	desc = pw_wonder.867.desc
@@ -5489,7 +5493,7 @@ planet_event = {
 }
 
 # Any Asteroid Impacts Planet
-planet_event = {
+carrier_event = {
 	id = pw_wonder.868
 	title = pw_wonder.868.name
 	desc = {
@@ -5506,11 +5510,11 @@ planet_event = {
 	is_triggered_only = yes
 
 	trigger = {
-		NOT = { has_planet_flag = pw_aligned_galactic_model_asteroid_impacted }
+		NOT = { has_carrier_flag = pw_aligned_galactic_model_asteroid_impacted }
 	}
 
 	immediate = {
-		set_planet_flag = pw_aligned_galactic_model_asteroid_impacted
+		set_carrier_flag = pw_aligned_galactic_model_asteroid_impacted
 		owner = {
 			country_event = { id = pw_wonder.869 days = 1 }
 		}
@@ -5590,7 +5594,7 @@ country_event = {
 # Panopticon -> id 900
 
 #On Panopticon built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.900
 	hide_window = yes
 	is_triggered_only = yes
@@ -5612,13 +5616,13 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.901 }
+		carrier_event = { id = pw_wonder.901 }
 		owner = { country_event = { id = pw_wonder.902 }}
 	}
 }
 
 #On first time Panopticon is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.901
 	title = pw_wonder.901.name
 	desc = pw_wonder.901.desc
@@ -5825,7 +5829,7 @@ country_event = {
 # Enigma Engine -> id 1000
 
 #On Enigma Engine built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1000
 	hide_window = yes
 	is_triggered_only = yes
@@ -5847,13 +5851,13 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1001 }
-		planet_event = { id = pw_wonder.1010 days = 60 random = 30 } #Event Chain
+		carrier_event = { id = pw_wonder.1001 }
+		carrier_event = { id = pw_wonder.1010 days = 60 random = 30 } #Event Chain
 	}
 }
 
 #On first time Enigma Engine is built (Machine Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1001
 	title = pw_wonder.1001.name
 	desc = pw_wonder.1001.desc
@@ -6104,7 +6108,7 @@ country_event = {
 }
 
 #Start Enigma Engine Energy
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1010
 	title = pw_wonder.1010.name
 	desc = pw_wonder.1010.desc
@@ -6128,13 +6132,13 @@ planet_event = {
 			clear_on_owner_change = yes
 		}
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1011 days = 180 random = 30 }
+			carrier_event = { id = pw_wonder.1011 days = 180 random = 30 }
 		}
 	}
 }
 
 #Enigma Engine Housing
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1011
 	title = pw_wonder.1011.name
 	desc = pw_wonder.1011.desc
@@ -6154,13 +6158,13 @@ planet_event = {
 			clear_on_owner_change = yes
 		}
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1012 days = 180 random = 30 }
+			carrier_event = { id = pw_wonder.1012 days = 180 random = 30 }
 		}
 	}
 }
 
 #Enigma Engine Art
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1012
 	title = pw_wonder.1012.name
 	desc = pw_wonder.1012.desc
@@ -6200,7 +6204,7 @@ planet_event = {
 				max = @tier3unitymax
 			}
 		}
-		planet_event = {
+		carrier_event = {
 			id = pw_wonder.1014
 			days = @pw_5years
 		}
@@ -6208,7 +6212,7 @@ planet_event = {
 }
 
 #Enigma Engine resolution
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1013
 	title = pw_wonder.1013.name
 	desc = pw_wonder.1013.desc
@@ -6240,7 +6244,7 @@ planet_event = {
 }
 
 #Enigma Engine resolution (don't remove modifiers)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1014
 	title = pw_wonder.1014.name
 	desc = pw_wonder.1014.desc
@@ -6295,7 +6299,7 @@ planet_event = {
 # Solipsist Debate Hall -> id 1100
 
 #On Solipsist Debate Hall built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1100
 	hide_window = yes
 	is_triggered_only = yes
@@ -6317,7 +6321,7 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1101 }
+		carrier_event = { id = pw_wonder.1101 }
 		owner = {
 			country_event = {
 				id = pw_solipsist_debate.1
@@ -6327,7 +6331,7 @@ planet_event = {
 }
 
 #On first time Solipsist Debate Hall is built (Hive Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1101
 	title = pw_wonder.1101.name
 	desc = pw_wonder.1101.desc
@@ -6554,7 +6558,7 @@ country_event = {
 # Guardian Angel -> id 1200
 
 #On Guardian Angel built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1200
 	hide_window = yes
 	is_triggered_only = yes
@@ -6576,12 +6580,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1201 } #Regular first time
-		planet_event = { id = pw_wonder.1202 } #Gestalt first time
-		planet_event = { id = pw_wonder.1203 } #Add flying fortress army
+		carrier_event = { id = pw_wonder.1201 } #Regular first time
+		carrier_event = { id = pw_wonder.1202 } #Gestalt first time
+		carrier_event = { id = pw_wonder.1203 } #Add flying fortress army
 
-		planet_event = { id = pw_wonder.1207 days = 60 random = 30 } #Guardian Angel Peace Choice.
-		planet_event = { id = pw_wonder.1204 days = @pw_halfYear } #Recursive check event
+		carrier_event = { id = pw_wonder.1207 days = 60 random = 30 } #Guardian Angel Peace Choice.
+		carrier_event = { id = pw_wonder.1204 days = @pw_halfYear } #Recursive check event
 
 		owner = { country_event = { #Subject/Overlord events
 			id = pw_wonder.1209
@@ -6591,7 +6595,7 @@ planet_event = {
 }
 
 #On first time Guardian Angel is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1201
 	title = pw_wonder.1201.name
 	desc = pw_wonder.1201.desc
@@ -6627,7 +6631,7 @@ planet_event = {
 }
 
 #On first time Guardian Angel is built (Gestalt Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1202
 	title = pw_wonder.1202.name
 	desc = pw_wonder.1202.desc
@@ -6663,7 +6667,7 @@ planet_event = {
 }
 
 #On Guardian Angel built add army
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1203
 	hide_window = yes
 	is_triggered_only = yes
@@ -6696,7 +6700,7 @@ planet_event = {
 }
 
 #Check if Guardian Angel was destroyed/replaced (recursive)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1204
 	hide_window = yes
 	is_triggered_only = yes
@@ -6723,16 +6727,16 @@ planet_event = {
 					has_deposit = pw_d_guardian_angel_scenic_set_piece
 				}
 			}
-			planet_event = { #Remove the Fortress
+			carrier_event = { #Remove the Fortress
 				id = pw_wonder.1205
 			}
-			planet_event = { #Remove the Deposits
+			carrier_event = { #Remove the Deposits
 				id = pw_wonder.1208
 				days = 30 #Different days, to spread the events
 			}
 		}
 		else = {
-			planet_event = { #Recursive event
+			carrier_event = { #Recursive event
 				id = pw_wonder.1204
 				days = @pw_halfYear
 			}
@@ -6741,7 +6745,7 @@ planet_event = {
 }
 
 # -> remove Flying Fortress
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1205
 	title = pw_wonder.1205.name
 	desc = pw_wonder.1205.desc
@@ -6769,7 +6773,7 @@ planet_event = {
 }
 
 #On Flying Fortress is rebuild
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1206
 	hide_window = yes
 	is_triggered_only = yes
@@ -6794,7 +6798,7 @@ planet_event = {
 }
 
 #Guardian Angel peace choice
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1207
 	title = pw_wonder.1207.name
 	desc = pw_wonder.1207.desc
@@ -6808,7 +6812,7 @@ planet_event = {
 	}
 
 	immediate = {
-		remove_planet_flag = pw_guardian_angel_choice
+		remove_carrier_flag = pw_guardian_angel_choice
 		if = {
 			limit = {
 				has_deposit = pw_d_guardian_angel_training
@@ -6925,12 +6929,12 @@ planet_event = {
 				pw_determine_war_drive_modifier = yes
 			}
 		}
-		set_planet_flag = pw_guardian_angel_choice
+		set_carrier_flag = pw_guardian_angel_choice
 	}
 }
 
 # -> remove Peace Choices
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1208
 	title = pw_wonder.1208.name
 	desc = pw_wonder.1208.desc
@@ -7065,7 +7069,7 @@ country_event = {
 # Stellar Sentinel -> id 1250
 
 #On Stellar Sentinel built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1250
 	hide_window = yes
 	is_triggered_only = yes
@@ -7092,12 +7096,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1251 } #Regular first time
+		carrier_event = { id = pw_wonder.1251 } #Regular first time
 	}
 }
 
 #On first time Stellar Sentinel is built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1251
 	title = pw_wonder.1251.name
 	desc = pw_wonder.1251.desc
@@ -7122,7 +7126,7 @@ planet_event = {
 # Crucible Mantle -> id 1300
 
 #On Crucible Mantle built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1300
 	hide_window = yes
 	is_triggered_only = yes
@@ -7144,10 +7148,10 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1301 } #Regular first time
-		planet_event = { id = pw_wonder.1302 } #Gestalt first time
-		planet_event = { id = pw_wonder.1303 } #Crucible Mantle Devastation
-		planet_event = { id = pw_wonder.1310 days = @pw_halfYear } #Recursive check event
+		carrier_event = { id = pw_wonder.1301 } #Regular first time
+		carrier_event = { id = pw_wonder.1302 } #Gestalt first time
+		carrier_event = { id = pw_wonder.1303 } #Crucible Mantle Devastation
+		carrier_event = { id = pw_wonder.1310 days = @pw_halfYear } #Recursive check event
 		owner = { country_event = { #Subject/Overlord events
 			id = pw_wonder.1324
 			days = 10
@@ -7156,7 +7160,7 @@ planet_event = {
 }
 
 #On first time Crucible Mantle is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1301
 	title = pw_wonder.1301.name
 	desc = pw_wonder.1301.desc
@@ -7230,7 +7234,7 @@ planet_event = {
 }
 
 #On first time Crucible Mantle is built (Gestalt Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1302
 	title = pw_wonder.1302.name
 	desc = pw_wonder.1302.desc
@@ -7270,14 +7274,14 @@ planet_event = {
 }
 
 #Mantle Crucible devastation events:
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1303
 	hide_window = yes
 	is_triggered_only = yes
 
 	immediate = {
-		set_planet_flag = pw_mantle_crucible_devastation_event
-		planet_event = {
+		set_carrier_flag = pw_mantle_crucible_devastation_event
+		carrier_event = {
 			id = pw_wonder.1304
 			days = @pw_1year
 			random = 60
@@ -7286,7 +7290,7 @@ planet_event = {
 }
 
 #Choose devastation effect:
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1304
 	hide_window = yes
 	is_triggered_only = yes
@@ -7299,7 +7303,7 @@ planet_event = {
 		if = {
 			limit = {
 				owner = { NOT = { has_country_flag = pw_mantle_crucible_end_devastation_project_complete }}
-				has_planet_flag = pw_mantle_crucible_devastation_event
+				has_carrier_flag = pw_mantle_crucible_devastation_event
 				OR ={
 					has_active_building = pw_building_mantle_crucible
 					has_active_building = pw_building_titan_forge
@@ -7328,10 +7332,10 @@ planet_event = {
 								NOT = { has_country_flag = pw_mantle_crucible_hide_devastation_events }
 							}
 						}
-						planet_event = { id = pw_wonder.1305 }
+						carrier_event = { id = pw_wonder.1305 }
 					}
 					else = {
-						planet_event = { id = pw_wonder.1315 }
+						carrier_event = { id = pw_wonder.1315 }
 					}
 				}
 				25 = { #Add 15 devastation
@@ -7355,10 +7359,10 @@ planet_event = {
 								NOT = { has_country_flag = pw_mantle_crucible_hide_devastation_events }
 							}
 						}
-						planet_event = { id = pw_wonder.1306 }
+						carrier_event = { id = pw_wonder.1306 }
 					}
 					else = {
-						planet_event = { id = pw_wonder.1316 }
+						carrier_event = { id = pw_wonder.1316 }
 					}
 				}
 				15 = { #Add 25 devastation
@@ -7372,10 +7376,10 @@ planet_event = {
 								NOT = { has_country_flag = pw_mantle_crucible_hide_devastation_events }
 							}
 						}
-						planet_event = { id = pw_wonder.1307 }
+						carrier_event = { id = pw_wonder.1307 }
 					}
 					else = {
-						planet_event = { id = pw_wonder.1317 }
+						carrier_event = { id = pw_wonder.1317 }
 					}
 				}
 				5 = { #Add 30 devastation
@@ -7394,10 +7398,10 @@ planet_event = {
 								NOT = { has_country_flag = pw_mantle_crucible_hide_devastation_events }
 							}
 						}
-						planet_event = { id = pw_wonder.1308 }
+						carrier_event = { id = pw_wonder.1308 }
 					}
 					else = {
-						planet_event = { id = pw_wonder.1318 }
+						carrier_event = { id = pw_wonder.1318 }
 					}
 				}
 				0 = { #Solves the Devastation
@@ -7460,12 +7464,12 @@ planet_event = {
 						owner = { has_country_flag = pw_mantle_crucible_end_devastation_project_begin }
 					}
 					owner = { set_country_flag = pw_mantle_crucible_end_devastation_project_begin }
-					planet_event = { id = pw_wonder.1320 }
+					carrier_event = { id = pw_wonder.1320 }
 				}
 			}
 		}
 		else = {
-			remove_planet_flag = pw_mantle_crucible_devastation_event
+			remove_carrier_flag = pw_mantle_crucible_devastation_event
 		}
 	}
 
@@ -7489,7 +7493,7 @@ planet_event = {
 }
 
 #Add 5 devastation
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1305
 	title = pw_wonder.1305.name
 	desc = pw_wonder.1305.desc
@@ -7502,7 +7506,7 @@ planet_event = {
 		name = UNFORTUNATE
 		add_planet_devastation = 5
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1304
 				days = @pw_10years
 				random = @pw_2years
@@ -7518,7 +7522,7 @@ planet_event = {
 			owner = {
 				set_country_flag = pw_mantle_crucible_hide_devastation_events
 			}
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1304
 				days = @pw_10years
 				random = @pw_2years
@@ -7528,7 +7532,7 @@ planet_event = {
 }
 
 #Add 15 devastation
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1306
 	title = pw_wonder.1305.name
 	desc = pw_wonder.1306.desc
@@ -7541,7 +7545,7 @@ planet_event = {
 		name = UNFORTUNATE
 		add_planet_devastation = 15
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1304
 				days = @pw_10years
 				random = @pw_2years
@@ -7557,7 +7561,7 @@ planet_event = {
 			owner = {
 				set_country_flag = pw_mantle_crucible_hide_devastation_events
 			}
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1304
 				days = @pw_10years
 				random = @pw_2years
@@ -7568,7 +7572,7 @@ planet_event = {
 
 
 #Add 25 devastation
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1307
 	title = pw_wonder.1305.name
 	desc = pw_wonder.1307.desc
@@ -7581,7 +7585,7 @@ planet_event = {
 		name = UNFORTUNATE
 		add_planet_devastation = 25
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1304
 				days = @pw_10years
 				random = @pw_2years
@@ -7597,7 +7601,7 @@ planet_event = {
 			owner = {
 				set_country_flag = pw_mantle_crucible_hide_devastation_events
 			}
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1304
 				days = @pw_10years
 				random = @pw_2years
@@ -7607,7 +7611,7 @@ planet_event = {
 }
 
 #Add 30 devastation
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1308
 	title = pw_wonder.1305.name
 	desc = pw_wonder.1308.desc
@@ -7620,7 +7624,7 @@ planet_event = {
 		name = UNFORTUNATE
 		add_planet_devastation = 30
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1304
 				days = @pw_10years
 				random = @pw_2years
@@ -7636,7 +7640,7 @@ planet_event = {
 			owner = {
 				set_country_flag = pw_mantle_crucible_hide_devastation_events
 			}
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1304
 				days = @pw_10years
 				random = @pw_2years
@@ -7646,7 +7650,7 @@ planet_event = {
 }
 
 #Check if Mantle Crucible was destroyed/replaced (recursive)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1310
 	hide_window = yes
 	is_triggered_only = yes
@@ -7661,16 +7665,16 @@ planet_event = {
 					has_modifier = pw_mod_mantle_crucible_uncompromising_industry
 				}
 			}
-			planet_event = { id = pw_wonder.1311 }
+			carrier_event = { id = pw_wonder.1311 }
 		}
 		else = {
-			planet_event = { id = pw_wonder.1310 days = @pw_halfYear }
+			carrier_event = { id = pw_wonder.1310 days = @pw_halfYear }
 		}
 	}
 }
 
 #Remove Mantle Crucible modifiers after it is removed
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1311
 	hide_window = yes
 	is_triggered_only = yes
@@ -7701,7 +7705,7 @@ planet_event = {
 }
 
 #Add 5 devastation (hidden)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1315
 	hide_window = yes
 	is_triggered_only = yes
@@ -7721,7 +7725,7 @@ planet_event = {
 			}
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1304
 				days = @pw_10years
 				random = @pw_2years
@@ -7731,7 +7735,7 @@ planet_event = {
 }
 
 #Add 15 devastation (hidden)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1316
 	hide_window = yes
 	is_triggered_only = yes
@@ -7751,7 +7755,7 @@ planet_event = {
 			}
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1304
 				days = @pw_10years
 				random = @pw_2years
@@ -7761,7 +7765,7 @@ planet_event = {
 }
 
 #Add 25 devastation (hidden)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1317
 	hide_window = yes
 	is_triggered_only = yes
@@ -7781,7 +7785,7 @@ planet_event = {
 			}
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1304
 				days = @pw_10years
 				random = @pw_2years
@@ -7791,7 +7795,7 @@ planet_event = {
 }
 
 #Add 30 devastation (hidden)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1318
 	hide_window = yes
 	is_triggered_only = yes
@@ -7811,7 +7815,7 @@ planet_event = {
 			}
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1304
 				days = @pw_10years
 				random = @pw_2years
@@ -7821,7 +7825,7 @@ planet_event = {
 }
 
 #Final Straw on devastation events:
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1320
 	title = pw_wonder.1320.name
 	desc = pw_wonder.1320.desc
@@ -8063,7 +8067,7 @@ country_event = {
 # Titan Forge -> id 1330
 
 #On Titan Forge built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1330
 	hide_window = yes
 	is_triggered_only = yes
@@ -8097,15 +8101,15 @@ planet_event = {
 			remove_modifier = pw_mod_mantle_crucible_uncompromising_industry
 		}
 
-		planet_event = { id = pw_wonder.1331 } #Regular first time
-		planet_event = { id = pw_wonder.1332 } #Gestalt first time
-		planet_event = { id = pw_wonder.1334 } #Remove Mantle Crucible mods
+		carrier_event = { id = pw_wonder.1331 } #Regular first time
+		carrier_event = { id = pw_wonder.1332 } #Gestalt first time
+		carrier_event = { id = pw_wonder.1334 } #Remove Mantle Crucible mods
 		owner = { country_event = { id = pw_art_exhibition.703 days = @pw_2years random = @pw_1year }} #Art Event
 	}
 }
 
 #On first time Titan Forge is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1331
 	title = pw_wonder.1331.name
 	desc = pw_wonder.1331.desc
@@ -8184,7 +8188,7 @@ planet_event = {
 }
 
 #On first time Titan Forge is built (Gestalt Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1332
 	title = pw_wonder.1332.name
 	desc = pw_wonder.1332.desc
@@ -8252,7 +8256,7 @@ planet_event = {
 }
 
 #On War Titan construction completes, remove the flag
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1333
 	hide_window = yes
 	is_triggered_only = yes
@@ -8260,13 +8264,13 @@ planet_event = {
 	immediate = {
 		if = {
 			limit = { from = { army_type = pw_army_war_titan }}
-			remove_planet_flag = pw_assembling_war_titan
+			remove_carrier_flag = pw_assembling_war_titan
 		}
 	}
 }
 
 #On Titan Forge completion remove Mantle Crucible modifiers
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1334
 	hide_window = yes
 	is_triggered_only = yes
@@ -8342,7 +8346,7 @@ country_event = {
 # Industrial Hearth -> id 1360
 
 #On Industrial Hearth built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1360
 	hide_window = yes
 	is_triggered_only = yes
@@ -8376,16 +8380,16 @@ planet_event = {
 			remove_modifier = pw_mod_mantle_crucible_uncompromising_industry
 		}
 
-		planet_event = { id = pw_wonder.1361 } #Regular first time
-		planet_event = { id = pw_wonder.1362 } #Gestalt first time
-		planet_event = { id = pw_wonder.1363 } #Remove Mantle Crucible mods
-		planet_event = { id = pw_wonder.1364 days = @pw_1year random = @pw_halfYear } #Development Events
+		carrier_event = { id = pw_wonder.1361 } #Regular first time
+		carrier_event = { id = pw_wonder.1362 } #Gestalt first time
+		carrier_event = { id = pw_wonder.1363 } #Remove Mantle Crucible mods
+		carrier_event = { id = pw_wonder.1364 days = @pw_1year random = @pw_halfYear } #Development Events
 		owner = { country_event = { id = pw_art_exhibition.704 days = @pw_2years random = @pw_1year }} #Art Event
 	}
 }
 
 #On first time Industrial Hearth is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1361
 	title = pw_wonder.1361.name
 	desc = pw_wonder.1361.desc
@@ -8466,7 +8470,7 @@ planet_event = {
 }
 
 #On first time Industrial Hearth is built (Gestalt Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1362
 	title = pw_wonder.1362.name
 	desc = pw_wonder.1362.desc
@@ -8500,7 +8504,7 @@ planet_event = {
 }
 
 #On Industrial Hearth completion remove Mantle Crucible modifiers
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1363
 	hide_window = yes
 	is_triggered_only = yes
@@ -8522,7 +8526,7 @@ planet_event = {
 }
 
 #Random Industrial Hearth development
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1364
 	hide_window = yes
 	is_triggered_only = yes
@@ -8547,7 +8551,7 @@ planet_event = {
 						owner = { has_tech_option = pw_tech_industrial_hearth_industry_military }
 					}
 				}
-				planet_event = { id = pw_wonder.1365 }
+				carrier_event = { id = pw_wonder.1365 }
 			}
 			10 = {
 				modifier = {
@@ -8558,7 +8562,7 @@ planet_event = {
 						owner = { has_tech_option = pw_tech_industrial_hearth_industry_civilian }
 					}
 				}
-				planet_event = { id = pw_wonder.1366 }
+				carrier_event = { id = pw_wonder.1366 }
 			}
 			10 = {
 				modifier = {
@@ -8571,7 +8575,7 @@ planet_event = {
 						}
 					}
 				}
-				planet_event = { id = pw_wonder.1367 }
+				carrier_event = { id = pw_wonder.1367 }
 			}
 			10 = {
 				modifier = {
@@ -8582,7 +8586,7 @@ planet_event = {
 						owner = { has_tech_option = pw_tech_industrial_hearth_housing }
 					}
 				}
-				planet_event = { id = pw_wonder.1368 }
+				carrier_event = { id = pw_wonder.1368 }
 			}
 			5 = {
 				modifier = {
@@ -8598,7 +8602,7 @@ planet_event = {
 					exists = owner
 					owner = { has_valid_civic = civic_environmentalist }
 				}
-				planet_event = { id = pw_wonder.1369 }
+				carrier_event = { id = pw_wonder.1369 }
 			}
 			10 = {
 				modifier = {
@@ -8614,7 +8618,7 @@ planet_event = {
 					exists = owner
 					owner = { is_megacorp = yes }
 				}
-				planet_event = { id = pw_wonder.1370 }
+				carrier_event = { id = pw_wonder.1370 }
 			}
 			10 = {
 				modifier = {
@@ -8630,7 +8634,7 @@ planet_event = {
 					exists = owner
 					owner = { is_megacorp = no }
 				}
-				planet_event = { id = pw_wonder.1371	}
+				carrier_event = { id = pw_wonder.1371	}
 			}
 			10 = {
 				modifier = {
@@ -8641,14 +8645,14 @@ planet_event = {
 						owner = { has_tech_option = pw_tech_industrial_hearth_production }
 					}
 				}
-				planet_event = { id = pw_wonder.1373 }
+				carrier_event = { id = pw_wonder.1373 }
 			}
 		}
 	}
 }
 
 #Industrial Hearth: industry military
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1365
 	title = pw_wonder.1365.name
 	desc = pw_wonder.1365.desc
@@ -8671,7 +8675,7 @@ planet_event = {
 			add_research_option = pw_tech_industrial_hearth_industry_military
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1364
 				days = @pw_5years
 				random = @pw_1year
@@ -8681,7 +8685,7 @@ planet_event = {
 }
 
 #Industrial Hearth: industry civilian
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1366
 	title = pw_wonder.1366.name
 	desc = pw_wonder.1366.desc
@@ -8704,7 +8708,7 @@ planet_event = {
 			add_research_option = pw_tech_industrial_hearth_industry_civilian
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1364
 				days = @pw_5years
 				random = @pw_1year
@@ -8714,7 +8718,7 @@ planet_event = {
 }
 
 #Industrial Hearth: capital
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1367
 	title = pw_wonder.1367.name
 	desc = pw_wonder.1367.desc
@@ -8745,7 +8749,7 @@ planet_event = {
 			}
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1364
 				days = @pw_5years
 				random = @pw_1year
@@ -8764,7 +8768,7 @@ planet_event = {
 }
 
 #Industrial Hearth: housing
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1368
 	title = pw_wonder.1368.name
 	desc = pw_wonder.1368.desc
@@ -8787,7 +8791,7 @@ planet_event = {
 			add_research_option = pw_tech_industrial_hearth_housing
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1364
 				days = @pw_5years
 				random = @pw_1year
@@ -8801,7 +8805,7 @@ planet_event = {
 			add_research_option = pw_tech_industrial_hearth_housing
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1364
 				days = @pw_5years
 				random = @pw_1year
@@ -8811,7 +8815,7 @@ planet_event = {
 }
 
 #Industrial Hearth: gardens
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1369
 	title = pw_wonder.1369.name
 	desc = pw_wonder.1369.desc
@@ -8834,7 +8838,7 @@ planet_event = {
 			add_research_option = pw_tech_industrial_hearth_gardens
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1364
 				days = @pw_5years
 				random = @pw_1year
@@ -8844,7 +8848,7 @@ planet_event = {
 }
 
 #Industrial Hearth: design
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1370
 	title = pw_wonder.1370.name
 	desc = pw_wonder.1370.desc
@@ -8872,7 +8876,7 @@ planet_event = {
 			clear_on_owner_change = yes
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1364
 				days = @pw_5years
 				random = @pw_1year
@@ -8891,7 +8895,7 @@ planet_event = {
 			clear_on_owner_change = yes
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1364
 				days = @pw_5years
 				random = @pw_1year
@@ -8901,7 +8905,7 @@ planet_event = {
 }
 
 #Industrial Hearth: design megacorp
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1371
 	title = pw_wonder.1371.name
 	desc = pw_wonder.1371.desc
@@ -8928,7 +8932,7 @@ planet_event = {
 			add_research_option = pw_tech_industrial_hearth_design_megacorp
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1364
 				days = @pw_5years
 				random = @pw_1year
@@ -8938,7 +8942,7 @@ planet_event = {
 }
 
 #Industrial Hearth: capital -> Success
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1372
 	title = pw_wonder.1372.name
 	desc = pw_wonder.1372.desc
@@ -8956,7 +8960,7 @@ planet_event = {
 }
 
 #Industrial Hearth: Jobs production/upkeep
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1373
 	title = pw_wonder.1373.name
 	desc = pw_wonder.1373.desc
@@ -8979,7 +8983,7 @@ planet_event = {
 			add_research_option = pw_tech_industrial_hearth_production
 		}
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.1364
 				days = @pw_5years
 				random = @pw_1year
@@ -8991,7 +8995,7 @@ planet_event = {
 # Pavilion of Wonders -> id 1400
 
 #On Pavilion of Wonders built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1400
 	hide_window = yes
 	is_triggered_only = yes
@@ -9013,14 +9017,14 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1401 } #Regular first time
+		carrier_event = { id = pw_wonder.1401 } #Regular first time
 		owner = { country_event = { id = pw_art_exhibition.703 days = @pw_1year random = @pw_1year }} #Titan Forge
 		owner = { country_event = { id = pw_art_exhibition.704 days = @pw_1year random = @pw_1year }} #Industrial Hearth
 	}
 }
 
 #On first time Pavilion of Wonders is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1401
 	title = pw_wonder.1401.name
 	desc = pw_wonder.1401.desc
@@ -9059,7 +9063,7 @@ planet_event = {
 # Fair of Worlds -> id 1430
 
 #On Fair of Worlds built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1430
 	hide_window = yes
 	is_triggered_only = yes
@@ -9086,14 +9090,14 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1431 } #Regular first time
+		carrier_event = { id = pw_wonder.1431 } #Regular first time
 		owner = { country_event = { id = pw_art_exhibition.703 days = @pw_1year random = @pw_1year }} #Titan Forge
 		owner = { country_event = { id = pw_art_exhibition.704 days = @pw_1year random = @pw_1year }} #Industrial Hearth
 	}
 }
 
 #On first time Fair of Worlds is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1431
 	title = pw_wonder.1431.name
 	desc = pw_wonder.1431.desc
@@ -9122,13 +9126,13 @@ planet_event = {
 			days = @pw_1year
 		}
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1432 days = @pw_halfYear random = @pw_halfYear }
+			carrier_event = { id = pw_wonder.1432 days = @pw_halfYear random = @pw_halfYear }
 		}
 	}
 }
 
 #Fair of Worlds: more envoys tech
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1432
 	title = pw_wonder.1432.name
 	desc = pw_wonder.1432.desc
@@ -9170,7 +9174,7 @@ planet_event = {
 # Museum of the Grotesque -> id 1460
 
 #On Museum of the Grotesque built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1460
 	hide_window = yes
 	is_triggered_only = yes
@@ -9197,14 +9201,14 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1461 } #Regular first time
+		carrier_event = { id = pw_wonder.1461 } #Regular first time
 		owner = { country_event = { id = pw_art_exhibition.703 days = @pw_1year random = @pw_1year }} #Titan Forge
 		owner = { country_event = { id = pw_art_exhibition.704 days = @pw_1year random = @pw_1year }} #Industrial Hearth
 	}
 }
 
 #On first time Museum of the Grotesque is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1461
 	title = pw_wonder.1461.name
 	desc = pw_wonder.1461.desc
@@ -9233,13 +9237,13 @@ planet_event = {
 			days = @pw_1year
 		}
 		hidden_effect = {
-			planet_event = { id = pw_wonder.1462 days = @pw_halfYear random = @pw_halfYear }
+			carrier_event = { id = pw_wonder.1462 days = @pw_halfYear random = @pw_halfYear }
 		}
 	}
 }
 
 #Museum of the Grotesque: more envoys
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1462
 	title = pw_wonder.1462.name
 	desc = pw_wonder.1462.desc
@@ -9315,7 +9319,7 @@ planet_event = {
 # Holy Reliquary -> id 1500
 
 #On Holy Reliquary built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1500
 	hide_window = yes
 	is_triggered_only = yes
@@ -9337,12 +9341,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1501 } #Regular first time
+		carrier_event = { id = pw_wonder.1501 } #Regular first time
 	}
 }
 
 #On first time Holy Reliquary is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1501
 	title = pw_wonder.1501.name
 	desc = pw_wonder.1501.desc
@@ -9390,7 +9394,7 @@ planet_event = {
 # Grand Archive -> id 1600
 
 #On Grand Archive built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1600
 	hide_window = yes
 	is_triggered_only = yes
@@ -9412,14 +9416,14 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1601 } #Regular first time
-		planet_event = { id = pw_wonder.1602 } #Second Time onwards
-		planet_event = { id = pw_wonder.1620 days = @pw_halfYear } #Recursive check
+		carrier_event = { id = pw_wonder.1601 } #Regular first time
+		carrier_event = { id = pw_wonder.1602 } #Second Time onwards
+		carrier_event = { id = pw_wonder.1620 days = @pw_halfYear } #Recursive check
 	}
 }
 
 #On first time Grand Archive is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1601
 	title = pw_wonder.1601.name
 	desc = pw_wonder.1601.desc
@@ -9439,7 +9443,7 @@ planet_event = {
 
 	immediate = {
 		owner = { set_country_flag = pw_grand_archive_built }
-		planet_event = { id = pw_grand_archive.1101 days = @pw_1year } #AI simulate deposits
+		carrier_event = { id = pw_grand_archive.1101 days = @pw_1year } #AI simulate deposits
 	}
 
 	option = {
@@ -9465,7 +9469,7 @@ planet_event = {
 }
 
 #On second (and onwards) time Grand Archive is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1602
 	title = pw_wonder.1602.name
 	desc = pw_wonder.1602.desc
@@ -9504,7 +9508,7 @@ planet_event = {
 		owner = {
 			every_owned_planet = {
 				limit = {
-					NOT = { is_planet = PREVPREV }
+					NOT = { is_same_value = PREVPREV }
 					OR = {
 						has_deposit = pw_d_ark_project
 						has_deposit = pw_d_cradle_initiative
@@ -9637,7 +9641,7 @@ planet_event = {
 }
 
 #Check if The Grand Archive has the needed deposits (recursive)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1620
 	hide_window = yes
 	is_triggered_only = yes
@@ -9692,15 +9696,15 @@ planet_event = {
 					}
 				}
 			}
-			planet_event = { id = pw_wonder.1621 }
+			carrier_event = { id = pw_wonder.1621 }
 		}
 		else = {
-			planet_event = { id = pw_wonder.1620 days = @pw_halfYear }
+			carrier_event = { id = pw_wonder.1620 days = @pw_halfYear }
 		}
 	}
 }
 
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1621
 	title = pw_wonder.1621.name
 	desc = pw_wonder.1621.desc
@@ -9842,7 +9846,7 @@ planet_event = {
 # Transplanetary Logistic Network -> id 1700
 
 #On Transplanetary Logistic Network built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1700
 	hide_window = yes
 	is_triggered_only = yes
@@ -9864,13 +9868,13 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1701 } #Regular first time
-		planet_event = { id = pw_wonder.1720 days = @pw_halfYear } #Recursive check
+		carrier_event = { id = pw_wonder.1701 } #Regular first time
+		carrier_event = { id = pw_wonder.1720 days = @pw_halfYear } #Recursive check
 	}
 }
 
 #On first time Transplanetary Logistic Network is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1701
 	title = pw_wonder.1701.name
 	desc = {
@@ -9901,7 +9905,7 @@ planet_event = {
 
 	immediate = {
 		owner = { set_country_flag = pw_transplanetary_logistics_network_built }
-		planet_event = { id = pw_wonder.1702 days = @pw_2years random = @pw_1year } #Shared Burden
+		carrier_event = { id = pw_wonder.1702 days = @pw_2years random = @pw_1year } #Shared Burden
 	}
 
 	option = {
@@ -9914,7 +9918,7 @@ planet_event = {
 }
 
 #Unlocks Shared Burdens tech:
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1702
 	title = pw_wonder.1702.name
 	desc = pw_wonder.1702.desc
@@ -9959,7 +9963,7 @@ planet_event = {
 }
 
 #When the TLN is destroyed/replaces -> demolish Infrastructure
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1703
 	title = pw_wonder.1703.name
 	desc = pw_wonder.1703.desc
@@ -10067,7 +10071,7 @@ planet_event = {
 }
 
 #When any Infrastructure development is completed:
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1705
 	hide_window = yes
 	is_triggered_only = yes
@@ -10088,7 +10092,7 @@ planet_event = {
 				scope = root
 			}
 		}
-		planet_event = {
+		carrier_event = {
 			id = pw_wonder.1706
 			days = 30
 			random = 30
@@ -10097,7 +10101,7 @@ planet_event = {
 }
 
 #After Development random events:
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1706
 	hide_window = yes
 	is_triggered_only = yes
@@ -10109,29 +10113,29 @@ planet_event = {
 	}
 
 	trigger = {
-		NOT = { has_planet_flag = pw_TLN_event }
+		NOT = { has_carrier_flag = pw_TLN_event }
 	}
 
 	immediate = {
 		random_list = {
 			20 = {} #Mostly nothing happens
 			1 = {
-				planet_event = { id = pw_wonder.1707 }
-				set_timed_planet_flag = {
+				carrier_event = { id = pw_wonder.1707 }
+				set_timed_carrier_flag = {
 					flag = pw_TLN_event
 					days = @pw_20years
 				}
 			}
 			1 =  {
-				planet_event = { id = pw_wonder.1708 }
-				set_timed_planet_flag = {
+				carrier_event = { id = pw_wonder.1708 }
+				set_timed_carrier_flag = {
 					flag = pw_TLN_event
 					days = @pw_20years
 				}
 			}
 			1 = {
-				planet_event = { id = pw_wonder.1709 }
-				set_timed_planet_flag = {
+				carrier_event = { id = pw_wonder.1709 }
+				set_timed_carrier_flag = {
 					flag = pw_TLN_event
 					days = @pw_20years
 				}
@@ -10143,8 +10147,8 @@ planet_event = {
 						is_militarist = yes
 					}
 				}
-				planet_event = { id = pw_wonder.1710 }
-				set_timed_planet_flag = {
+				carrier_event = { id = pw_wonder.1710 }
+				set_timed_carrier_flag = {
 					flag = pw_TLN_event
 					days = @pw_20years
 				}
@@ -10156,15 +10160,15 @@ planet_event = {
 						is_pacifist = yes
 					}
 				}
-				planet_event = { id = pw_wonder.1711 }
-				set_timed_planet_flag = {
+				carrier_event = { id = pw_wonder.1711 }
+				set_timed_carrier_flag = {
 					flag = pw_TLN_event
 					days = @pw_20years
 				}
 			}
 			1 = {
-				planet_event = { id = pw_wonder.1712 }
-				set_timed_planet_flag = {
+				carrier_event = { id = pw_wonder.1712 }
+				set_timed_carrier_flag = {
 					flag = pw_TLN_event
 					days = @pw_20years
 				}
@@ -10174,7 +10178,7 @@ planet_event = {
 }
 
 #The right to be lazy
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1707
 	title = pw_wonder.1707.name
 	desc = pw_wonder.1707.desc
@@ -10227,7 +10231,7 @@ planet_event = {
 }
 
 #Path to progress
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1708
 	title = pw_wonder.1708.name
 	desc = pw_wonder.1708.desc
@@ -10280,7 +10284,7 @@ planet_event = {
 }
 
 #Mutual Aid
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1709
 	title = pw_wonder.1709.name
 	desc = pw_wonder.1709.desc
@@ -10320,7 +10324,7 @@ planet_event = {
 }
 
 #Inspired Militia
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1710
 	title = pw_wonder.1710.name
 	desc = pw_wonder.1710.desc
@@ -10377,7 +10381,7 @@ planet_event = {
 }
 
 #Inspired peace
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1711
 	title = pw_wonder.1711.name
 	desc = pw_wonder.1711.desc
@@ -10423,7 +10427,7 @@ planet_event = {
 }
 
 #Surprising Inventions
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1712
 	title = pw_wonder.1712.name
 	desc = pw_wonder.1712.desc
@@ -10492,7 +10496,7 @@ planet_event = {
 }
 
 #Street Carnival
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1713
 	title = pw_wonder.1713.name
 	desc = pw_wonder.1713.desc
@@ -10507,11 +10511,11 @@ planet_event = {
 	}
 
 	trigger = {
-		NOT = { has_planet_flag = pw_TLN_event }
+		NOT = { has_carrier_flag = pw_TLN_event }
 	}
 
 	immediate = {
-		set_timed_planet_flag = {
+		set_timed_carrier_flag = {
 			flag = pw_TLN_event
 			days = @pw_10years
 		}
@@ -10529,7 +10533,7 @@ planet_event = {
 }
 
 #Final TLN development built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1715
 	title = pw_wonder.1715.name
 	desc = pw_wonder.1715.desc
@@ -10540,7 +10544,7 @@ planet_event = {
 
 	trigger = {
 		exists = owner
-		NOT = { has_planet_flag = pw_TLN_complete_event }
+		NOT = { has_carrier_flag = pw_TLN_complete_event }
 		has_deposit = pw_d_infrastructure_luxury_distribution
 		has_deposit = pw_d_infrastructure_crisis_responders
 		has_deposit = pw_d_infrastructure_arts_installations
@@ -10548,7 +10552,7 @@ planet_event = {
 	}
 
 	immediate = {
-		set_planet_flag = pw_TLN_complete_event
+		set_carrier_flag = pw_TLN_complete_event
 	}
 
 	#Modifier
@@ -10572,7 +10576,7 @@ planet_event = {
 }
 
 #Check if TLS was destroyed/replaced (recursive)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1720
 	hide_window = yes
 	is_triggered_only = yes
@@ -10603,10 +10607,10 @@ planet_event = {
 					has_deposit = pw_d_infrastructure_industrial_unions
 				}
 			}
-			planet_event = { id = pw_wonder.1703 }
+			carrier_event = { id = pw_wonder.1703 }
 		}
 		else = {
-			planet_event = { id = pw_wonder.1720 days = @pw_halfYear }
+			carrier_event = { id = pw_wonder.1720 days = @pw_halfYear }
 		}
 	}
 }
@@ -10614,7 +10618,7 @@ planet_event = {
 # Forbidden City -> id 1800
 
 #On Forbidden City built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1800
 	hide_window = yes
 	is_triggered_only = yes
@@ -10636,13 +10640,13 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1801 } #Regular first time
-		planet_event = { id = pw_wonder.1820 days = @pw_halfYear } #Recursive Check
+		carrier_event = { id = pw_wonder.1801 } #Regular first time
+		carrier_event = { id = pw_wonder.1820 days = @pw_halfYear } #Recursive Check
 	}
 }
 
 #On first time Forbidden City is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1801
 	title = pw_wonder.1801.name
 	desc = pw_wonder.1801.desc
@@ -10674,7 +10678,7 @@ planet_event = {
 }
 
 #When the FC is destroyed/replaces -> demolish Infrastructure
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1802
 	title = pw_wonder.1802.name
 	desc = pw_wonder.1802.desc
@@ -10809,7 +10813,7 @@ planet_event = {
 }
 
 #When the Seat of Power is completed, destroy the old one
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1803
 	title = pw_wonder.1803.name
 	desc = pw_wonder.1803.desc
@@ -10831,7 +10835,7 @@ planet_event = {
 			any_owned_planet = {
 				OR = {
 					AND = { #Seat of Power is somewhere else
-						NOT = { is_planet = this }
+						NOT = { is_same_value = root }
 						has_deposit = pw_d_infrastructure_seat_of_power
 					}
 					OR = {
@@ -10850,7 +10854,7 @@ planet_event = {
 		owner = {
 			every_owned_planet = {
 				limit = {
-					NOT = { is_planet = root }
+					NOT = { is_same_value = root }
 					has_deposit = pw_d_infrastructure_seat_of_power
 				}
 				remove_deposit = pw_d_infrastructure_seat_of_power
@@ -10895,7 +10899,7 @@ planet_event = {
 }
 
 #When the Throne Room is completed, destroy the old one
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1804
 	title = pw_wonder.1804.name
 	desc = pw_wonder.1804.desc
@@ -10920,7 +10924,7 @@ planet_event = {
 			any_owned_planet = {
 				OR = {
 					AND = { #Seat of Power is somewhere else
-						NOT = { is_planet = this }
+						NOT = { is_same_value = root }
 						OR = {
 							has_deposit = pw_d_infrastructure_throne_room
 							has_deposit = pw_d_infrastructure_imperial_holy_throne
@@ -10938,7 +10942,7 @@ planet_event = {
 		owner = {
 			every_owned_planet = {
 				limit = {
-					NOT = { is_planet = root }
+					NOT = { is_same_value = root }
 					OR = {
 						has_deposit = pw_d_infrastructure_throne_room
 						has_deposit = pw_d_infrastructure_imperial_holy_throne
@@ -10977,7 +10981,7 @@ planet_event = {
 }
 
 #When any Infrastructure development is completed:
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1805
 	hide_window = yes
 	is_triggered_only = yes
@@ -10998,7 +11002,7 @@ planet_event = {
 				scope = root
 			}
 		}
-		planet_event = {
+		carrier_event = {
 			id = pw_wonder.1806
 			days = 30
 			random = 30
@@ -11007,7 +11011,7 @@ planet_event = {
 }
 
 #After Development random events:
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1806
 	hide_window = yes
 	is_triggered_only = yes
@@ -11019,7 +11023,7 @@ planet_event = {
 	}
 
 	trigger = {
-		NOT = { has_planet_flag = pw_FC_event }
+		NOT = { has_carrier_flag = pw_FC_event }
 	}
 
 	immediate = {
@@ -11027,29 +11031,29 @@ planet_event = {
 		random_list = {
 			20 = {} #Mostly nothing happens
 			1 = {
-				planet_event = { id = pw_wonder.1807 }
-				set_timed_planet_flag = {
+				carrier_event = { id = pw_wonder.1807 }
+				set_timed_carrier_flag = {
 					flag = pw_FC_event
 					days = @pw_20years
 				}
 			}
 			1 =  {
-				planet_event = { id = pw_wonder.1808 }
-				set_timed_planet_flag = {
+				carrier_event = { id = pw_wonder.1808 }
+				set_timed_carrier_flag = {
 					flag = pw_FC_event
 					days = @pw_20years
 				}
 			}
 			1 = {
-				planet_event = { id = pw_wonder.1809 }
-				set_timed_planet_flag = {
+				carrier_event = { id = pw_wonder.1809 }
+				set_timed_carrier_flag = {
 					flag = pw_FC_event
 					days = @pw_20years
 				}
 			}
 			1 = {
-				planet_event = { id = pw_wonder.1810 }
-				set_timed_planet_flag = {
+				carrier_event = { id = pw_wonder.1810 }
+				set_timed_carrier_flag = {
 					flag = pw_FC_event
 					days = @pw_20years
 				}
@@ -11059,7 +11063,7 @@ planet_event = {
 }
 
 #Hunger Protests
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1807
 	title = pw_wonder.1807.name
 	desc = pw_wonder.1807.desc
@@ -11149,7 +11153,7 @@ planet_event = {
 }
 
 #Their orderly Place
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1808
 	title = pw_wonder.1808.name
 	desc = pw_wonder.1808.desc
@@ -11234,7 +11238,7 @@ planet_event = {
 }
 
 #Humble Donations
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1809
 	title = pw_wonder.1809.name
 	desc = pw_wonder.1809.desc
@@ -11316,7 +11320,7 @@ planet_event = {
 }
 
 #Ruler Visit
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1810
 	title = pw_wonder.1810.name
 	desc = pw_wonder.1810.desc
@@ -11407,7 +11411,7 @@ planet_event = {
 }
 
 #Masquerade
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1811
 	title = pw_wonder.1811.name
 	desc = pw_wonder.1811.desc
@@ -11422,11 +11426,11 @@ planet_event = {
 	}
 
 	trigger = {
-		NOT = { has_planet_flag = pw_FC_event }
+		NOT = { has_carrier_flag = pw_FC_event }
 	}
 
 	immediate = {
-		set_timed_planet_flag = {
+		set_timed_carrier_flag = {
 			flag = pw_FC_event
 			days = @pw_10years
 		}
@@ -11444,7 +11448,7 @@ planet_event = {
 }
 
 #Final FC development built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1815
 	title = pw_wonder.1815.name
 	desc = pw_wonder.1815.desc
@@ -11455,7 +11459,7 @@ planet_event = {
 
 	trigger = {
 		exists = owner
-		NOT = { has_planet_flag = pw_FC_complete_event }
+		NOT = { has_carrier_flag = pw_FC_complete_event }
 		has_deposit = pw_d_infrastructure_personal_guardian
 		has_deposit = pw_d_infrastructure_galactic_bureau
 		OR = {
@@ -11465,7 +11469,7 @@ planet_event = {
 	}
 
 	immediate = {
-		set_planet_flag = pw_FC_complete_event
+		set_carrier_flag = pw_FC_complete_event
 	}
 
 	#Modifier
@@ -11489,7 +11493,7 @@ planet_event = {
 }
 
 #Check if FC was destroyed/replaced (recursive)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1820
 	hide_window = yes
 	is_triggered_only = yes
@@ -11524,11 +11528,11 @@ planet_event = {
 					has_deposit = pw_d_infrastructure_war_room
 				}
 			}
-			planet_event = { id = pw_wonder.1802 }
+			carrier_event = { id = pw_wonder.1802 }
 		}
 		else_if = {
 			limit = { has_active_building = pw_building_forbidden_city }
-			planet_event = { id = pw_wonder.1820 days = @pw_halfYear }
+			carrier_event = { id = pw_wonder.1820 days = @pw_halfYear }
 		}
 	}
 }
@@ -11537,7 +11541,7 @@ planet_event = {
 # Festival Plaza -> id 1900
 
 #On Festival Plaza built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1900
 	hide_window = yes
 	is_triggered_only = yes
@@ -11559,14 +11563,14 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.1901 } #Regular first time
-		planet_event = { id = pw_wonder.1905 days = @pw_halfYear } #Recursive Check
-		planet_event = { id = pw_wonder.1930 days = @pw_2years } #Black Letters Days
+		carrier_event = { id = pw_wonder.1901 } #Regular first time
+		carrier_event = { id = pw_wonder.1905 days = @pw_halfYear } #Recursive Check
+		carrier_event = { id = pw_wonder.1930 days = @pw_2years } #Black Letters Days
 	}
 }
 
 #On first time Festival Plaza is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1901
 	title = pw_wonder.1901.name
 	desc = pw_wonder.1901.desc
@@ -11611,7 +11615,7 @@ planet_event = {
 }
 
 #Festival Plaza select festival
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1902
 	title = pw_wonder.1902.name
 	desc = pw_wonder.1902.desc
@@ -11625,7 +11629,7 @@ planet_event = {
 	}
 
 	immediate = {
-		set_planet_flag = pw_festival_plaza_choice
+		set_carrier_flag = pw_festival_plaza_choice
 		if = {
 			limit = {
 				has_modifier = pw_mod_FP_festivities_of_plenitude
@@ -11742,12 +11746,12 @@ planet_event = {
 				pw_determine_peace_stability_modifier = yes
 			}
 		}
-		remove_planet_flag = pw_festival_plaza_choice
+		remove_carrier_flag = pw_festival_plaza_choice
 	}
 }
 
 #Check if FP was destroyed/replaced (recursive)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1905
 	hide_window = yes
 	is_triggered_only = yes
@@ -11765,17 +11769,17 @@ planet_event = {
 					has_modifier = pw_mod_FP_chivalrous_ceremonies
 				}
 			}
-			planet_event = { id = pw_wonder.1906 }
+			carrier_event = { id = pw_wonder.1906 }
 		}
 		else_if = {
 			limit = { has_active_building = pw_building_festival_plaza }
-			planet_event = { id = pw_wonder.1905 days = @pw_halfYear }
+			carrier_event = { id = pw_wonder.1905 days = @pw_halfYear }
 		}
 	}
 }
 
 #When the FP is destroyed/replaces -> remove modifiers
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1906
 	title = pw_wonder.1906.name
 	desc = pw_wonder.1906.desc
@@ -11867,7 +11871,7 @@ country_event = {
 				}
 			}
 			#Remove the planetary modifiers:
-			planet_event = { id = pw_wonder.1911 }
+			carrier_event = { id = pw_wonder.1911 }
 		}
 		#Start recurring peace check:
 		country_event = { id = pw_wonder.1915 days = @pw_halfYear }
@@ -11883,7 +11887,7 @@ country_event = {
 }
 
 #Remove festivities from planets
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1911
 	hide_window = yes
 	is_triggered_only = yes
@@ -11903,32 +11907,32 @@ planet_event = {
 		if = {
 			limit = { has_modifier = pw_mod_FP_festivities_of_plenitude }
 			remove_modifier = pw_mod_FP_festivities_of_plenitude
-			set_planet_flag = pw_FP_has_festivities_of_plenitude_mod
+			set_carrier_flag = pw_FP_has_festivities_of_plenitude_mod
 		}
 		else_if = {
 			limit = { has_modifier = pw_mod_FP_fertility_bacchanal }
 			remove_modifier = pw_mod_FP_fertility_bacchanal
-			set_planet_flag = pw_FP_has_fertility_bacchanal_mod
+			set_carrier_flag = pw_FP_has_fertility_bacchanal_mod
 		}
 		else_if = {
 			limit = { has_modifier = pw_mod_FP_cultivate_peace }
 			remove_modifier = pw_mod_FP_cultivate_peace
-			set_planet_flag = pw_FP_has_cultivate_peace_mod
+			set_carrier_flag = pw_FP_has_cultivate_peace_mod
 		}
 		else_if = {
 			limit = { has_modifier = pw_mod_FP_harvest_festival }
 			remove_modifier = pw_mod_FP_harvest_festival
-			set_planet_flag = pw_FP_has_harvest_festival_mod
+			set_carrier_flag = pw_FP_has_harvest_festival_mod
 		}
 		else_if = {
 			limit = { has_modifier = pw_mod_FP_commemorate_perfection }
 			remove_modifier = pw_mod_FP_commemorate_perfection
-			set_planet_flag = pw_FP_has_commemorate_perfection_mod
+			set_carrier_flag = pw_FP_has_commemorate_perfection_mod
 		}
 		else_if = {
 			limit = { has_modifier = pw_mod_FP_chivalrous_ceremonies }
 			remove_modifier = pw_mod_FP_chivalrous_ceremonies
-			set_planet_flag = pw_FP_has_chivalrous_ceremonies_mod
+			set_carrier_flag = pw_FP_has_chivalrous_ceremonies_mod
 		}
 	}
 }
@@ -11991,16 +11995,16 @@ country_event = {
 		every_owned_planet = {
 			limit = {
 				OR = { #Has one of the flags:
-					has_planet_flag = pw_FP_has_festivities_of_plenitude_mod
-					has_planet_flag = pw_FP_has_fertility_bacchanal_mod
-					has_planet_flag = pw_FP_has_cultivate_peace_mod
-					has_planet_flag = pw_FP_has_harvest_festival_mod
-					has_planet_flag = pw_FP_has_commemorate_perfection_mod
-					has_planet_flag = pw_FP_has_chivalrous_ceremonies_mod
+					has_carrier_flag = pw_FP_has_festivities_of_plenitude_mod
+					has_carrier_flag = pw_FP_has_fertility_bacchanal_mod
+					has_carrier_flag = pw_FP_has_cultivate_peace_mod
+					has_carrier_flag = pw_FP_has_harvest_festival_mod
+					has_carrier_flag = pw_FP_has_commemorate_perfection_mod
+					has_carrier_flag = pw_FP_has_chivalrous_ceremonies_mod
 				}
 			}
 			#Remove the planetary modifiers:
-			planet_event = { id = pw_wonder.1922 }
+			carrier_event = { id = pw_wonder.1922 }
 		}
 	}
 
@@ -12015,26 +12019,26 @@ country_event = {
 }
 
 #Reset the festivities to the planets
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1922
 	hide_window = yes
 	is_triggered_only = yes
 
 	trigger = {
 		OR = { #Has one of the flags:
-			has_planet_flag = pw_FP_has_festivities_of_plenitude_mod
-			has_planet_flag = pw_FP_has_fertility_bacchanal_mod
-			has_planet_flag = pw_FP_has_cultivate_peace_mod
-			has_planet_flag = pw_FP_has_harvest_festival_mod
-			has_planet_flag = pw_FP_has_commemorate_perfection_mod
-			has_planet_flag = pw_FP_has_chivalrous_ceremonies_mod
+			has_carrier_flag = pw_FP_has_festivities_of_plenitude_mod
+			has_carrier_flag = pw_FP_has_fertility_bacchanal_mod
+			has_carrier_flag = pw_FP_has_cultivate_peace_mod
+			has_carrier_flag = pw_FP_has_harvest_festival_mod
+			has_carrier_flag = pw_FP_has_commemorate_perfection_mod
+			has_carrier_flag = pw_FP_has_chivalrous_ceremonies_mod
 		}
 	}
 
 	immediate = {
 		if = {
-			limit = { has_planet_flag = pw_FP_has_festivities_of_plenitude_mod }
-			remove_planet_flag = pw_FP_has_festivities_of_plenitude_mod
+			limit = { has_carrier_flag = pw_FP_has_festivities_of_plenitude_mod }
+			remove_carrier_flag = pw_FP_has_festivities_of_plenitude_mod
 			if = {
 				limit = { has_active_building = pw_building_festival_plaza }
 				add_modifier = {
@@ -12044,8 +12048,8 @@ planet_event = {
 			}
 		}
 		else_if = {
-			limit = { has_planet_flag = pw_FP_has_fertility_bacchanal_mod }
-			remove_planet_flag = pw_FP_has_fertility_bacchanal_mod
+			limit = { has_carrier_flag = pw_FP_has_fertility_bacchanal_mod }
+			remove_carrier_flag = pw_FP_has_fertility_bacchanal_mod
 			if = {
 				limit = { has_active_building = pw_building_festival_plaza }
 				add_modifier = {
@@ -12055,8 +12059,8 @@ planet_event = {
 			}
 		}
 		else_if = {
-			limit = { has_planet_flag = pw_FP_has_cultivate_peace_mod }
-			remove_planet_flag = pw_FP_has_cultivate_peace_mod
+			limit = { has_carrier_flag = pw_FP_has_cultivate_peace_mod }
+			remove_carrier_flag = pw_FP_has_cultivate_peace_mod
 			if = {
 				limit = { has_active_building = pw_building_festival_plaza }
 				add_modifier = {
@@ -12066,8 +12070,8 @@ planet_event = {
 			}
 		}
 		else_if = {
-			limit = { has_planet_flag = pw_FP_has_harvest_festival_mod }
-			remove_planet_flag = pw_FP_has_harvest_festival_mod
+			limit = { has_carrier_flag = pw_FP_has_harvest_festival_mod }
+			remove_carrier_flag = pw_FP_has_harvest_festival_mod
 			if = {
 				limit = { has_active_building = pw_building_festival_plaza }
 				add_modifier = {
@@ -12077,8 +12081,8 @@ planet_event = {
 			}
 		}
 		else_if = {
-			limit = { has_planet_flag = pw_FP_has_commemorate_perfection_mod }
-			remove_planet_flag = pw_FP_has_commemorate_perfection_mod
+			limit = { has_carrier_flag = pw_FP_has_commemorate_perfection_mod }
+			remove_carrier_flag = pw_FP_has_commemorate_perfection_mod
 			if = {
 				limit = { has_active_building = pw_building_festival_plaza }
 				add_modifier = {
@@ -12088,8 +12092,8 @@ planet_event = {
 			}
 		}
 		else_if = {
-			limit = { has_planet_flag = pw_FP_has_chivalrous_ceremonies_mod }
-			remove_planet_flag = pw_FP_has_chivalrous_ceremonies_mod
+			limit = { has_carrier_flag = pw_FP_has_chivalrous_ceremonies_mod }
+			remove_carrier_flag = pw_FP_has_chivalrous_ceremonies_mod
 			if = {
 				limit = { has_active_building = pw_building_festival_plaza }
 				add_modifier = {
@@ -12113,7 +12117,7 @@ country_event = {
 }
 
 #Black Letter Day decision (Peaceful)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.1930
 	title = pw_wonder.1930.name
 	desc = pw_wonder.1930.desc
@@ -12178,7 +12182,7 @@ planet_event = {
 # Martial Avenue -> id 2000
 
 #On Martial Avenue built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2000
 	hide_window = yes
 	is_triggered_only = yes
@@ -12200,14 +12204,14 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.2001 } #Regular first time
-		planet_event = { id = pw_wonder.2005 days = @pw_halfYear } #Recursive Check
-		planet_event = { id = pw_wonder.2030 days = @pw_2years } #Black Letters Days
+		carrier_event = { id = pw_wonder.2001 } #Regular first time
+		carrier_event = { id = pw_wonder.2005 days = @pw_halfYear } #Recursive Check
+		carrier_event = { id = pw_wonder.2030 days = @pw_2years } #Black Letters Days
 	}
 }
 
 #On first time Martial Avenue is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2001
 	title = pw_wonder.2001.name
 	desc = pw_wonder.2001.desc
@@ -12278,7 +12282,7 @@ country_event = {
 }
 
 #Festival Plaza select festival
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2003
 	title = pw_wonder.2003.name
 	desc = pw_wonder.2003.desc
@@ -12292,7 +12296,7 @@ planet_event = {
 	}
 
 	immediate = {
-		set_planet_flag = pw_martial_avenue_choice
+		set_carrier_flag = pw_martial_avenue_choice
 		if = {
 			limit = {
 				has_modifier = pw_mod_MA_military_parade
@@ -12443,12 +12447,12 @@ planet_event = {
 				pw_determine_war_drive_modifier = yes
 			}
 		}
-		remove_planet_flag = pw_martial_avenue_choice
+		remove_carrier_flag = pw_martial_avenue_choice
 	}
 }
 
 #Check if MA was destroyed/replaced (recursive)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2005
 	hide_window = yes
 	is_triggered_only = yes
@@ -12469,17 +12473,17 @@ planet_event = {
 					has_modifier =pw_mod_MA_toxic_jousting_tournaments
 				}
 			}
-			planet_event = { id = pw_wonder.2006 }
+			carrier_event = { id = pw_wonder.2006 }
 		}
 		else_if = {
 			limit = { has_active_building = pw_building_martial_avenue }
-			planet_event = { id = pw_wonder.2005 days = @pw_halfYear }
+			carrier_event = { id = pw_wonder.2005 days = @pw_halfYear }
 		}
 	}
 }
 
 #When the MA is destroyed/replaces -> remove modifiers
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2006
 	title = pw_wonder.2006.name
 	desc = pw_wonder.2006.desc
@@ -12588,7 +12592,7 @@ country_event = {
 				}
 			}
 			#Remove the planetary modifiers:
-			planet_event = { id = pw_wonder.2011 }
+			carrier_event = { id = pw_wonder.2011 }
 		}
 		#Start recurring peace check:
 		country_event = { id = pw_wonder.2015 days = @pw_halfYear }
@@ -12604,7 +12608,7 @@ country_event = {
 }
 
 #Remove parades from planets
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2011
 	hide_window = yes
 	is_triggered_only = yes
@@ -12626,37 +12630,37 @@ planet_event = {
 		if = {
 			limit = { has_modifier = pw_mod_MA_military_parade }
 			remove_modifier = pw_mod_MA_military_parade
-			set_planet_flag = pw_MA_has_military_parade_mod
+			set_carrier_flag = pw_MA_has_military_parade_mod
 		}
 		else_if = {
 			limit = { has_modifier = pw_mod_MA_flight_of_the_corvettes }
 			remove_modifier = pw_mod_MA_flight_of_the_corvettes
-			set_planet_flag = pw_MA_has_flight_of_the_corvettes_mod
+			set_carrier_flag = pw_MA_has_flight_of_the_corvettes_mod
 		}
 		else_if = {
 			limit = { has_modifier = pw_mod_MA_national_march }
 			remove_modifier = pw_mod_MA_national_march
-			set_planet_flag = pw_MA_has_national_march_mod
+			set_carrier_flag = pw_MA_has_national_march_mod
 		}
 		else_if = {
 			limit = { has_modifier = pw_mod_MA_combat_demonstrations }
 			remove_modifier = pw_mod_MA_combat_demonstrations
-			set_planet_flag = pw_MA_has_combat_demonstrations_mod
+			set_carrier_flag = pw_MA_has_combat_demonstrations_mod
 		}
 		else_if = {
 			limit = { has_modifier = pw_mod_MA_merchants_of_war }
 			remove_modifier = pw_mod_MA_merchants_of_war
-			set_planet_flag = pw_MA_has_merchants_of_war_mod
+			set_carrier_flag = pw_MA_has_merchants_of_war_mod
 		}
 		else_if = {
 			limit = { has_modifier = pw_mod_MA_march_of_the_dead }
 			remove_modifier = pw_mod_MA_march_of_the_dead
-			set_planet_flag = pw_MA_has_march_of_the_dead_mod
+			set_carrier_flag = pw_MA_has_march_of_the_dead_mod
 		}
 		else_if = {
 			limit = { has_modifier = pw_mod_MA_toxic_jousting_tournaments }
 			remove_modifier = pw_mod_MA_toxic_jousting_tournaments
-			set_planet_flag = pw_MA_toxic_jousting_tournament_mod
+			set_carrier_flag = pw_MA_toxic_jousting_tournament_mod
 		}
 		#Add next modifier:
 		if = {
@@ -12768,17 +12772,17 @@ country_event = {
 		every_owned_planet = {
 			limit = {
 				OR = { #Has one of the flags:
-					has_planet_flag = pw_MA_has_military_parade_mod
-					has_planet_flag = pw_MA_has_flight_of_the_corvettes_mod
-					has_planet_flag = pw_MA_has_national_march_mod
-					has_planet_flag = pw_MA_has_combat_demonstrations_mod
-					has_planet_flag = pw_MA_has_merchants_of_war_mod
-					has_planet_flag = pw_MA_has_march_of_the_dead_mod
-					has_planet_flag = pw_MA_toxic_jousting_tournament_mod
+					has_carrier_flag = pw_MA_has_military_parade_mod
+					has_carrier_flag = pw_MA_has_flight_of_the_corvettes_mod
+					has_carrier_flag = pw_MA_has_national_march_mod
+					has_carrier_flag = pw_MA_has_combat_demonstrations_mod
+					has_carrier_flag = pw_MA_has_merchants_of_war_mod
+					has_carrier_flag = pw_MA_has_march_of_the_dead_mod
+					has_carrier_flag = pw_MA_toxic_jousting_tournament_mod
 				}
 			}
 			#Remove the planetary modifiers:
-			planet_event = { id = pw_wonder.2022 }
+			carrier_event = { id = pw_wonder.2022 }
 		}
 	}
 
@@ -12793,20 +12797,20 @@ country_event = {
 }
 
 #Reset the parades to the planets
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2022
 	hide_window = yes
 	is_triggered_only = yes
 
 	trigger = {
 		OR = { #Has one of the flags:
-			has_planet_flag = pw_MA_has_military_parade_mod
-			has_planet_flag = pw_MA_has_flight_of_the_corvettes_mod
-			has_planet_flag = pw_MA_has_national_march_mod
-			has_planet_flag = pw_MA_has_combat_demonstrations_mod
-			has_planet_flag = pw_MA_has_merchants_of_war_mod
-			has_planet_flag = pw_MA_has_march_of_the_dead_mod
-			has_planet_flag = pw_MA_toxic_jousting_tournament_mod
+			has_carrier_flag = pw_MA_has_military_parade_mod
+			has_carrier_flag = pw_MA_has_flight_of_the_corvettes_mod
+			has_carrier_flag = pw_MA_has_national_march_mod
+			has_carrier_flag = pw_MA_has_combat_demonstrations_mod
+			has_carrier_flag = pw_MA_has_merchants_of_war_mod
+			has_carrier_flag = pw_MA_has_march_of_the_dead_mod
+			has_carrier_flag = pw_MA_toxic_jousting_tournament_mod
 		}
 	}
 
@@ -12821,8 +12825,8 @@ planet_event = {
 		}
 
 		if = {
-			limit = { has_planet_flag = pw_MA_has_military_parade_mod }
-			remove_planet_flag = pw_MA_has_military_parade_mod
+			limit = { has_carrier_flag = pw_MA_has_military_parade_mod }
+			remove_carrier_flag = pw_MA_has_military_parade_mod
 			if = {
 				limit = { has_active_building = pw_building_martial_avenue }
 				add_modifier = {
@@ -12832,8 +12836,8 @@ planet_event = {
 			}
 		}
 		else_if = {
-			limit = { has_planet_flag = pw_MA_has_flight_of_the_corvettes_mod }
-			remove_planet_flag = pw_MA_has_flight_of_the_corvettes_mod
+			limit = { has_carrier_flag = pw_MA_has_flight_of_the_corvettes_mod }
+			remove_carrier_flag = pw_MA_has_flight_of_the_corvettes_mod
 			if = {
 				limit = { has_active_building = pw_building_martial_avenue }
 				add_modifier = {
@@ -12843,8 +12847,8 @@ planet_event = {
 			}
 		}
 		else_if = {
-			limit = { has_planet_flag = pw_MA_has_national_march_mod }
-			remove_planet_flag = pw_MA_has_national_march_mod
+			limit = { has_carrier_flag = pw_MA_has_national_march_mod }
+			remove_carrier_flag = pw_MA_has_national_march_mod
 			if = {
 				limit = { has_active_building = pw_building_martial_avenue }
 				add_modifier = {
@@ -12854,8 +12858,8 @@ planet_event = {
 			}
 		}
 		else_if = {
-			limit = { has_planet_flag = pw_MA_has_combat_demonstrations_mod }
-			remove_planet_flag = pw_MA_has_combat_demonstrations_mod
+			limit = { has_carrier_flag = pw_MA_has_combat_demonstrations_mod }
+			remove_carrier_flag = pw_MA_has_combat_demonstrations_mod
 			if = {
 				limit = { has_active_building = pw_building_martial_avenue }
 				add_modifier = {
@@ -12865,8 +12869,8 @@ planet_event = {
 			}
 		}
 		else_if = {
-			limit = { has_planet_flag = pw_MA_has_merchants_of_war_mod }
-			remove_planet_flag = pw_MA_has_merchants_of_war_mod
+			limit = { has_carrier_flag = pw_MA_has_merchants_of_war_mod }
+			remove_carrier_flag = pw_MA_has_merchants_of_war_mod
 			if = {
 				limit = { has_active_building = pw_building_martial_avenue }
 				add_modifier = {
@@ -12876,8 +12880,8 @@ planet_event = {
 			}
 		}
 		else_if = {
-			limit = { has_planet_flag = pw_MA_has_march_of_the_dead_mod }
-			remove_planet_flag = pw_MA_has_march_of_the_dead_mod
+			limit = { has_carrier_flag = pw_MA_has_march_of_the_dead_mod }
+			remove_carrier_flag = pw_MA_has_march_of_the_dead_mod
 			if = {
 				limit = { has_active_building = pw_building_martial_avenue }
 				add_modifier = {
@@ -12887,8 +12891,8 @@ planet_event = {
 			}
 		}
 		else_if = {
-			limit = { has_planet_flag = pw_MA_toxic_jousting_tournament_mod }
-			remove_planet_flag = pw_MA_toxic_jousting_tournament_mod
+			limit = { has_carrier_flag = pw_MA_toxic_jousting_tournament_mod }
+			remove_carrier_flag = pw_MA_toxic_jousting_tournament_mod
 			if = {
 				limit = { has_active_building = pw_building_martial_avenue }
 				add_modifier = {
@@ -12913,7 +12917,7 @@ country_event = {
 
 
 #Black Letter Day decision (Militarist)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2030
 	title = pw_wonder.2030.name
 	desc = pw_wonder.2030.desc
@@ -12978,7 +12982,7 @@ planet_event = {
 # Living Spire -> id 2100
 
 #On Living Spire 0 built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2100
 	hide_window = yes
 	is_triggered_only = yes
@@ -13000,12 +13004,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.2110 } #Regular first time
+		carrier_event = { id = pw_wonder.2110 } #Regular first time
 	}
 }
 
 #On Living Spire 1 built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2101
 	hide_window = yes
 	is_triggered_only = yes
@@ -13032,12 +13036,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.2111 } #Regular first time
+		carrier_event = { id = pw_wonder.2111 } #Regular first time
 	}
 }
 
 #On Living Spire 2 built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2102
 	hide_window = yes
 	is_triggered_only = yes
@@ -13064,12 +13068,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.2112 } #Regular first time
+		carrier_event = { id = pw_wonder.2112 } #Regular first time
 	}
 }
 
 #On Living Spire 3 built (final)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2103
 	hide_window = yes
 	is_triggered_only = yes
@@ -13103,17 +13107,17 @@ planet_event = {
 					has_country_flag = pw_living_spire_built
 				}
 			}
-			planet_event = { id = pw_wonder.2114 } #Second time onwards
+			carrier_event = { id = pw_wonder.2114 } #Second time onwards
 		}
 		else = {
-			planet_event = { id = pw_wonder.2113 } #Regular first time
+			carrier_event = { id = pw_wonder.2113 } #Regular first time
 		}
-		planet_event = { id = pw_wonder.2105 days = @pw_1year } #Recursive check if destroyed
+		carrier_event = { id = pw_wonder.2105 days = @pw_1year } #Recursive check if destroyed
 	}
 }
 
 #On first time Living Spire 0 is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2110
 	title = pw_wonder.2110.name
 	desc = pw_wonder.2110.desc
@@ -13168,7 +13172,7 @@ planet_event = {
 }
 
 #On first time Living Spire 1 is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2111
 	title = pw_wonder.2111.name
 	desc = pw_wonder.2111.desc
@@ -13216,7 +13220,7 @@ planet_event = {
 }
 
 #On first time Living Spire 2 is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2112
 	title = pw_wonder.2112.name
 	desc = pw_wonder.2112.desc
@@ -13264,7 +13268,7 @@ planet_event = {
 }
 
 #On first time Living Spire 3 is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2113
 	title = pw_wonder.2113.name
 	desc = pw_wonder.2113.desc
@@ -13312,7 +13316,7 @@ planet_event = {
 
 	after = {
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.2120
 				days = 10
 			}
@@ -13321,7 +13325,7 @@ planet_event = {
 }
 
 #On second time onwards Living Spire 3 is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2114
 	title = pw_wonder.2114.name
 	desc = pw_wonder.2114.desc
@@ -13342,7 +13346,7 @@ planet_event = {
 	option = {
 		name = pw_wonder.2114.a
 		hidden_effect = {
-			planet_event = {
+			carrier_event = {
 				id = pw_wonder.2120
 				days = 10
 			}
@@ -13351,7 +13355,7 @@ planet_event = {
 }
 
 #Check if LS was destroyed/replaced (recursive)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2105
 	hide_window = yes
 	is_triggered_only = yes
@@ -13378,16 +13382,16 @@ planet_event = {
 					has_modifier = pw_pm_living_spire_designation_order
 				}
 			}
-			planet_event = { id = pw_wonder.2106 }
+			carrier_event = { id = pw_wonder.2106 }
 		}
 		else = {
-			planet_event = { id = pw_wonder.2105 days = @pw_halfYear }
+			carrier_event = { id = pw_wonder.2105 days = @pw_halfYear }
 		}
 	}
 }
 
 #When the LS is destroyed/replaced -> remove designation
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2106
 	title = pw_wonder.2106.name
 	desc = pw_wonder.2106.desc
@@ -13483,7 +13487,7 @@ planet_event = {
 }
 
 #Choose a designation for the Spire
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2120
 	title = pw_wonder.2120.name
 	desc = pw_wonder.2120.desc
@@ -13750,7 +13754,7 @@ planet_event = {
 # Conduit of Unity -> id 2200
 
 #On Conduit of Unity 0 built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2200
 	hide_window = yes
 	is_triggered_only = yes
@@ -13772,12 +13776,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.2210 } #Regular first time
+		carrier_event = { id = pw_wonder.2210 } #Regular first time
 	}
 }
 
 #On Conduit of Unity 1 built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2201
 	hide_window = yes
 	is_triggered_only = yes
@@ -13804,13 +13808,13 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.2211 } #Gestalt first time
-		planet_event = { id = pw_wonder.2202 days = @pw_1year } #Recursive check for CoU destroyed
+		carrier_event = { id = pw_wonder.2211 } #Gestalt first time
+		carrier_event = { id = pw_wonder.2202 days = @pw_1year } #Recursive check for CoU destroyed
 	}
 }
 
 #Check if CoU was destroyed/replaced (recursive)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2202
 	hide_window = yes
 	is_triggered_only = yes
@@ -13831,16 +13835,16 @@ planet_event = {
 					has_deposit = pw_d_integration_chamber_of_reflection
 				}
 			}
-			planet_event = { id = pw_wonder.2203 }
+			carrier_event = { id = pw_wonder.2203 }
 		}
 		else = {
-			planet_event = { id = pw_wonder.2202 days = @pw_halfYear }
+			carrier_event = { id = pw_wonder.2202 days = @pw_halfYear }
 		}
 	}
 }
 
 #When the CoU is destroyed/replaces -> demolish Integrations
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2203
 	title = pw_wonder.2203.name
 	desc = pw_wonder.2203.desc
@@ -13906,7 +13910,7 @@ planet_event = {
 }
 
 #On Conduit of Unity Integration is completed
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2205
 	hide_window = yes
 	is_triggered_only = yes
@@ -13931,7 +13935,7 @@ planet_event = {
 }
 
 #On first time Conduit of Unity 0 is built (Gestalt Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2210
 	title = pw_wonder.2210.name
 	desc = pw_wonder.2210.desc
@@ -13963,7 +13967,7 @@ planet_event = {
 }
 
 #On first time Conduit of Unity 1 is built (Gestalt Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2211
 	title = pw_wonder.2211.name
 	desc = pw_wonder.2211.desc
@@ -13993,7 +13997,7 @@ planet_event = {
 # Nostalgia Paradise -> id 2300
 
 #On Nostalgia Paradise built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2300
 	hide_window = yes
 	is_triggered_only = yes
@@ -14015,16 +14019,16 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.2301 } #Regular first time
-		planet_event = { id = pw_wonder.2302 } #Servitor first time
+		carrier_event = { id = pw_wonder.2301 } #Regular first time
+		carrier_event = { id = pw_wonder.2302 } #Servitor first time
 
-		planet_event = { id = pw_wonder.2310 days = 5 } #Select first theme
-		planet_event = { id = pw_wonder.2305 days = @pw_1year } #Recursive check if destroyed
+		carrier_event = { id = pw_wonder.2310 days = 5 } #Select first theme
+		carrier_event = { id = pw_wonder.2305 days = @pw_1year } #Recursive check if destroyed
 	}
 }
 
 #On first time Nostalgia Paradise is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2301
 	title = pw_wonder.2301.name
 	desc = pw_wonder.2301.desc
@@ -14061,7 +14065,7 @@ planet_event = {
 }
 
 #On first time Nostalgia Paradise is built (Rogue Servitors)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2302
 	title = pw_wonder.2302.name
 	desc = pw_wonder.2302.desc
@@ -14098,7 +14102,7 @@ planet_event = {
 }
 
 #Check if NP was destroyed/replaced (recursive)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2305
 	hide_window = yes
 	is_triggered_only = yes
@@ -14122,16 +14126,16 @@ planet_event = {
 					has_modifier = pw_pm_nostalgia_paradise_theme_automated_resort
 				}
 			}
-			planet_event = { id = pw_wonder.2306 }
+			carrier_event = { id = pw_wonder.2306 }
 		}
 		else = {
-			planet_event = { id = pw_wonder.2305 days = @pw_halfYear }
+			carrier_event = { id = pw_wonder.2305 days = @pw_halfYear }
 		}
 	}
 }
 
 #When the NP is destroyed/replaced -> Remove Modifiers
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2306
 	title = pw_wonder.2306.name
 	desc = pw_wonder.2306.desc
@@ -14212,7 +14216,7 @@ planet_event = {
 }
 
 #Choose a theme for the Nostalgia Paradise
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2310
 	title = pw_wonder.2310.name
 	desc = pw_wonder.2310.desc
@@ -14379,7 +14383,7 @@ planet_event = {
 # Unhallowed Necropolis -> id 2400
 
 #On Unhallowed Necropolis built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2400
 	hide_window = yes
 	is_triggered_only = yes
@@ -14401,13 +14405,13 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.2401 } #Regular first time
-		planet_event = { id = pw_wonder.2402 } #Gestalt first time
+		carrier_event = { id = pw_wonder.2401 } #Regular first time
+		carrier_event = { id = pw_wonder.2402 } #Gestalt first time
 	}
 }
 
 #On first time Unhallowed Necropolis is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2401
 	title = pw_wonder.2401.name
 	desc = {
@@ -14521,7 +14525,7 @@ planet_event = {
 }
 
 #On first time Unhallowed Necropolis is built (Gestalt)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2402
 	title = pw_wonder.2402.name
 	desc = {
@@ -14688,7 +14692,7 @@ planet_event = {
 }
 
 #On planet change class to something that is not tomb (or modded necro world?)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2403
 	title = pw_wonder.2403.name
 	desc = pw_wonder.2403.desc
@@ -14748,7 +14752,7 @@ planet_event = {
 # Blossoming Preserve -> id 2500
 
 #On Blossoming Preserve built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2500
 	hide_window = yes
 	is_triggered_only = yes
@@ -14770,13 +14774,13 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.2501 } #Regular first time
-		planet_event = { id = pw_wonder.2502 } #Servitor first time
+		carrier_event = { id = pw_wonder.2501 } #Regular first time
+		carrier_event = { id = pw_wonder.2502 } #Servitor first time
 	}
 }
 
 #On first time Blossoming Preserve is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2501
 	title = pw_wonder.2501.name
 	desc = pw_wonder.2501.desc
@@ -14848,7 +14852,7 @@ planet_event = {
 }
 
 #On first time Blossoming Preserve is built (Gestalt)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2502
 	title = pw_wonder.2502.name
 	desc = pw_wonder.2502.desc
@@ -14922,7 +14926,7 @@ planet_event = {
 # Department of Xenoeconomics -> id 2600
 
 #On Department of Xenoeconomics built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2600
 	hide_window = yes
 	is_triggered_only = yes
@@ -14944,12 +14948,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.2601 } #Regular first time
+		carrier_event = { id = pw_wonder.2601 } #Regular first time
 	}
 }
 
 #On first time Department of Xenoeconomics is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2601
 	title = pw_wonder.2601.name
 	desc = pw_wonder.2601.desc
@@ -15009,7 +15013,7 @@ planet_event = {
 # Feastings Grounds -> id 2700
 
 #On Feastings Grounds built
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2700
 	hide_window = yes
 	is_triggered_only = yes
@@ -15031,12 +15035,12 @@ planet_event = {
 			}
 		}
 
-		planet_event = { id = pw_wonder.2701 } #Regular first time
+		carrier_event = { id = pw_wonder.2701 } #Regular first time
 	}
 }
 
 #On first time Feastings Grounds is built (Regular Empire)
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2701
 	title = pw_wonder.2701.name
 	desc = pw_wonder.2701.desc
@@ -15113,7 +15117,7 @@ planet_event = {
 }
 
 #Feasting grounds decision: choose Feast to begin
-planet_event = {
+carrier_event = {
 	id = pw_wonder.2710
 	title = pw_wonder.2710.name
 	desc = pw_wonder.2710.desc
@@ -15127,12 +15131,12 @@ planet_event = {
 	}
 
 	immediate = {
-		set_planet_flag = pw_FG_is_choosing_feast
+		set_carrier_flag = pw_FG_is_choosing_feast
 	}
 
 	trigger = {
 		has_active_building = pw_building_feasting_grounds
-		NOT = { has_planet_flag = pw_FG_is_choosing_feast }
+		NOT = { has_carrier_flag = pw_FG_is_choosing_feast }
 	}
 
 	option = {
@@ -15443,7 +15447,7 @@ planet_event = {
 
 	after = {
 		hidden_effect = {
-			remove_planet_flag = pw_FG_is_choosing_feast
+			remove_carrier_flag = pw_FG_is_choosing_feast
 		}
 	}
 }


### PR DESCRIPTION
-- Changed "planet_flag" to "carrier_flag".
-- Changed "planet_event" to "carrier_event".
-- Changed "is_planet = root" condition on planet scope to "is_same_value = root". -- Changed "pop_cat_slave_happiness" modifier to "pop_slave_happiness". -- Added "situation_log_category" property to event chains. -- Updated job weight.
- Integrated pull request #25 (Fixed living spire building added entertainer job slots only 1 or 3.).
- Infernal DLC districts are supported now.
- Fixed "Capricorn's Heart" system spawned.

Note 1: I Blocked PW Ascension Perk and the gateway tech for nomadic empires. I am feeling most PW buildings are not suited for arkships.
Note 2: I did some playthrough, but I might missed some issues.
Note 3: my previous pull request (#25. "#35" in commit log is typo) is integrated, so it can be rejected.